### PR TITLE
Delete author and date in dev_history templates

### DIFF
--- a/inst/dev-template-additional.Rmd
+++ b/inst/dev-template-additional.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd empty"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/dev-template-full.Rmd
+++ b/inst/dev-template-full.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/dev-template-minimal.Rmd
+++ b/inst/dev-template-minimal.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd empty"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/dev-template-teaching.Rmd
+++ b/inst/dev-template-teaching.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/tests-templates/dev-template-no-example-no-tests.Rmd
+++ b/inst/tests-templates/dev-template-no-example-no-tests.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/tests-templates/dev-template-stop-duplicate-fun.Rmd
+++ b/inst/tests-templates/dev-template-stop-duplicate-fun.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/tests-templates/dev-template-stop-duplicate-label.Rmd
+++ b/inst/tests-templates/dev-template-stop-duplicate-label.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/tests-templates/dev-template-test-parse-nothing.Rmd
+++ b/inst/tests-templates/dev-template-test-parse-nothing.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/tests-templates/dev-template-tests-special-char.Rmd
+++ b/inst/tests-templates/dev-template-tests-special-char.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sébastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console

--- a/inst/tests-templates/dev-template-tests.Rmd
+++ b/inst/tests-templates/dev-template-tests.Rmd
@@ -1,7 +1,5 @@
 ---
 title: "dev_history.Rmd for working package"
-author: "Sebastien Rochette"
-date: "23/01/2021"
 output: html_document
 editor_options: 
   chunk_output_type: console


### PR DESCRIPTION
There is no need to include author and date information in the YAML
header of the dev_history.Rmd templates.
- Author is already included in the DESCRIPTION.
- Date is nor meaningful nor useful here.