### PR TITLE
Properly ignore dev/ in new fusens

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,4 +20,3 @@ rstudio\_dotrstudio
 ^doc$
 ^Meta$
 ^CONTRIBUTING\.md$
-^dev/$

--- a/R/add_dev_history.R
+++ b/R/add_dev_history.R
@@ -93,9 +93,9 @@ add_dev_history <- function(pkg = ".", overwrite = FALSE,
   # .Rbuildignore
   # usethis::use_build_ignore(dev_dir) # Cannot be used outside project
   if (length(list.files(pkg, pattern = "[.]Rproj")) == 0) {
-    lines <- c(paste0("^", basename(dev_dir), "/$"), "^\\.here$")
+    lines <- c(paste0("^", basename(dev_dir), "$"), "^\\.here$")
   } else {
-    lines <- c(paste0("^", basename(dev_dir), "/$"))
+    lines <- c(paste0("^", basename(dev_dir), "$"))
   }
 
   buildfile <- normalizePath(file.path(pkg, ".Rbuildignore"), mustWork = FALSE)

--- a/tests/testthat/test-add_dev_history.R
+++ b/tests/testthat/test-add_dev_history.R
@@ -13,7 +13,7 @@ test_that("add_dev_history adds dev_history.Rmd and co.", {
   rbuildignore_file <- file.path(dummypackage, ".Rbuildignore")
   expect_true(file.exists(rbuildignore_file))
   rbuildignore_lines <- readLines(rbuildignore_file)
-  expect_true(any(grepl("^dev/$", rbuildignore_lines, fixed = TRUE)))
+  expect_true(any(grepl("^dev$", rbuildignore_lines, fixed = TRUE)))
   expect_true(any(grepl("[.]here", rbuildignore_lines)))
 
   dev_lines <- readLines(dev_path)


### PR DESCRIPTION
Correct .Rbuildignore syntax.
Closes #79.

However, I find it worrying that this was not detected by the first check triggered by `fusen::inflate()`.
I did not dig more into it for the moment.