### PR TITLE
Add more explicit comments in templates

### DIFF
--- a/inst/dev-template-additional.Rmd
+++ b/inst/dev-template-additional.Rmd
@@ -30,17 +30,16 @@ test_that("my_function works properly", {
 })
 ```
 
+<!-- # Inflate your package -->
+
+<!-- You're one inflate from paper to box. -->
+<!-- Build your package from this very Rmd using `fusen::inflate()` in the `development` chunk below. -->
 
 ```{r development-1, eval=FALSE}
 # Run but keep eval=FALSE to avoid infinite loop
 # Execute in the console directly
 fusen::inflate(rmd = "dev/dev_history.Rmd")
 ```
-
-<!-- # Inflate your package -->
-
-<!-- You're one inflate from paper to box. -->
-<!-- Build your package from this very Rmd using `fusen::inflate()` -->
 
 <!-- - Verify your `"DESCRIPTION"` file has been updated -->
 <!-- - Verify your function is in `"R/"` directory -->

--- a/inst/dev-template-full.Rmd
+++ b/inst/dev-template-full.Rmd
@@ -135,7 +135,7 @@ fusen::inflate(rmd = "dev/dev_history.Rmd")
 # Inflate your package
 
 You're one inflate from paper to box.
-Build your package from this very Rmd using `fusen::inflate()`
+Build your package from this very Rmd using `fusen::inflate()` in the `development` chunk above.
 
 - Verify your `"DESCRIPTION"` file has been updated
 - Verify your function is in `"R/"` directory

--- a/inst/dev-template-minimal.Rmd
+++ b/inst/dev-template-minimal.Rmd
@@ -47,17 +47,16 @@ test_that("my_function works properly", {
 })
 ```
 
+<!-- # Inflate your package -->
+
+<!-- You're one inflate from paper to box. -->
+<!-- Build your package from this very Rmd using `fusen::inflate()` in the `development` chunk below. -->
 
 ```{r development-1, eval=FALSE}
 # Run but keep eval=FALSE to avoid infinite loop
 # Execute in the console directly
 fusen::inflate(rmd = "dev/dev_history.Rmd")
 ```
-
-<!-- # Inflate your package -->
-
-<!-- You're one inflate from paper to box. -->
-<!-- Build your package from this very Rmd using `fusen::inflate()` -->
 
 <!-- - Verify your `"DESCRIPTION"` file has been updated -->
 <!-- - Verify your function is in `"R/"` directory -->

--- a/inst/dev-template-teaching.Rmd
+++ b/inst/dev-template-teaching.Rmd
@@ -142,8 +142,7 @@ That's it ! This the end of the documented story of our package. All components 
 <!-- # Inflate your package -->
 
 <!-- You're one inflate from paper to box. -->
-<!-- Build your package from this very Rmd using `fusen::inflate()` -->
-
+<!-- Build your package from this very Rmd using `fusen::inflate()` in the `development` chunk below. -->
 
 ```{r development-1, eval=FALSE}
 # Run but keep eval=FALSE to avoid infinite loop


### PR DESCRIPTION
Points user to chunk where `fusen::inflate()` is.
Closes #77.