### PR TITLE
fix: allow writing "function(" in doc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - Publish your {fusen} project on a GitHub website with one command: `init_share_on_github()`
 
+## Bug fixes
+
+- Fix using `function(` in documentation (#174, @FlorenceMounier)
+
 # fusen 0.4.1
 
 ## New features

--- a/R/inflate-utils.R
+++ b/R/inflate-utils.R
@@ -33,12 +33,14 @@ parse_fun <- function(x) { # x <- rmd_fun[3,]
   # Clean extra space between #' and @
   code <- gsub(pattern = "#'\\s*@", "#' @", code)
 
-
   # Get all #'
   all_hastags <- grep("^#'", code)
 
+  # Get all #
+  all_comments <- grep("^#", code)
+
   # Get all functions
-  fun_positions <- setdiff(grep(regex_isfunction, code), all_hastags)
+  fun_positions <- setdiff(grep(regex_isfunction, code), all_comments)
 
   # find function name
   fun_name <- stringi::stri_extract_first_regex(

--- a/R/inflate-utils.R
+++ b/R/inflate-utils.R
@@ -29,21 +29,28 @@ parse_fun <- function(x) { # x <- rmd_fun[3,]
   #   c("zaza <- function()", "zozo <- R6Class()", "zuzu <- R6::R6Class()"),
   #   regex_extract_fun_name
   # )
-  #
-  # find function name
-  fun_name <- stringi::stri_extract_first_regex(
-    code[grep(regex_isfunction, code)],
-    regex_extract_fun_name
-  ) %>%
-    gsub(" ", "", .) # remove spaces
 
   # Clean extra space between #' and @
   code <- gsub(pattern = "#'\\s*@", "#' @", code)
 
-  # Find start of function
-  first_function_start <- grep(regex_isfunction, code)[1]
+
   # Get all #'
   all_hastags <- grep("^#'", code)
+
+  # Get all functions
+  fun_positions <- setdiff(grep(regex_isfunction, code), all_hastags)
+
+  # find function name
+  fun_name <- stringi::stri_extract_first_regex(
+    code[fun_positions],
+    regex_extract_fun_name
+  ) %>%
+    gsub(" ", "", .) # remove spaces
+
+  # Find start of function
+  first_function_start <- fun_positions[1]
+
+  # Get last hastags above first fun
   if (length(all_hastags) != 0) {
     last_hastags_above_first_fun <- max(all_hastags[all_hastags < first_function_start])
   } else {

--- a/inst/tests-templates/dev-template-word-function-in-doc.Rmd
+++ b/inst/tests-templates/dev-template-word-function-in-doc.Rmd
@@ -1,0 +1,73 @@
+---
+title: "dev_history.Rmd empty"
+output: html_document
+editor_options: 
+  chunk_output_type: console
+---
+
+```{r development, include=FALSE}
+library(testthat)
+```
+
+# my_function 
+
+Uses "function()" in parameter's documentation
+    
+```{r function-my_function}
+#' Call a stat function
+#' 
+#' Run a stat function (ex : mean, min, max)
+#' 
+#' @param x A numeric vector
+#' @param stat_function A stat function (ex : mean, min, max)
+#' 
+#' @examples
+#' 
+#' @export
+my_function <- function(x, stat_function){
+  stat_function(x, na.rm = TRUE)
+}
+```
+  
+```{r example-my_function}
+my_function(x = rnorm(100), stat_function = mean)
+```
+  
+```{r tests-my_function}
+test_that("my_function works", {
+  expect_true(inherits(my_function, "function")) 
+})
+```
+
+Should be saved in a proper .R file
+
+```{r function-add_one}
+#' Add one to a numeric value
+#'  
+#' @param x A numeric value
+#' 
+#' @examples
+#' 
+#' @export
+add_one <- function(x){
+  x + 1
+}
+```
+  
+```{r example-add_one}
+add_one(x = 1)
+```
+  
+```{r tests-add_one}
+test_that("add_one works", {
+  expect_equal(object = add_one(1), expected = 2) 
+})
+```
+  
+
+
+```{r development-1, eval=FALSE}
+# Run but keep eval=FALSE to avoid infinite loop
+# Execute in the console directly
+fusen::inflate(flat_file = "dev/dev_history.Rmd")
+```

--- a/inst/tests-templates/dev-template-word-function-in-doc.Rmd
+++ b/inst/tests-templates/dev-template-word-function-in-doc.Rmd
@@ -25,6 +25,7 @@ Uses "function()" in parameter's documentation
 #' @examples
 #' 
 #' @export
+# function() I can write "function()" in code comments really everywhere!
 my_function <- function(x, stat_function){
   stat_function(x, na.rm = TRUE) # function() comment after code
 # function() in code comment

--- a/inst/tests-templates/dev-template-word-function-in-doc.Rmd
+++ b/inst/tests-templates/dev-template-word-function-in-doc.Rmd
@@ -17,6 +17,7 @@ Uses "function()" in parameter's documentation
 #' Call a stat function
 #' 
 #' Run a stat function (ex : mean, min, max)
+#' function()
 #' 
 #' @param x A numeric vector
 #' @param stat_function A stat function (ex : mean, min, max)
@@ -25,7 +26,8 @@ Uses "function()" in parameter's documentation
 #' 
 #' @export
 my_function <- function(x, stat_function){
-  stat_function(x, na.rm = TRUE)
+  stat_function(x, na.rm = TRUE) # function() comment after code
+# function() in code comment
 }
 ```
   

--- a/tests/testthat/test-inflate-part2.R
+++ b/tests/testthat/test-inflate-part2.R
@@ -1020,7 +1020,7 @@ usethis::with_project(dummypackage, {
     expect_equal(list.files(the_codes), "my_function.R") # not c("add_one.R", "my_function.R")
     # Check that .R contains example
     code <- readLines(file.path(dummypackage, "R", "my_function.R"))
-    any(grepl("^#'\\s*my_function\\(x", code))
+    expect_true(any(grepl("^#'\\s*my_function\\(x", code)))
   })
 })
 


### PR DESCRIPTION
tags: fix

Why?
may be used but has to be read as a part of documentation and not as a function by `inflate()`

What?
- Create a new test-template Rmd file in "inst/tests-templates" that produces this bug with `inflate()`
- Add a new unit test in "tests/testthat/test-inflate-part2.R" that runs the new test-template and test the proper reading and inflate() of the functions from the template
- Modify parse_fun() to remove commented lines before extracting functions names and first_fuction_start position in the code

Issue #174