### PR TITLE
feat: prepare for new {fusen} version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,3 +51,4 @@ Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.1
+FusenVersion: 0.4.1

--- a/R/inflate.R
+++ b/R/inflate.R
@@ -245,6 +245,13 @@ inflate <- function(pkg = ".", flat_file,
     message("`vignette_name` is empty: no vignette created")
   }
 
+  # Update version in Description
+  desc_file <- file.path(pkg, "DESCRIPTION")
+  version <- as.character(utils::packageVersion("fusen"))
+  the_desc <- desc::desc(file = desc_file)
+  the_desc$set(FusenVersion = version)
+  the_desc$write(file = desc_file)
+
   # Run attachment
   if (isTRUE(document)) {
     attachment::att_amend_desc(path = pkg)

--- a/tests/testthat/test-inflate-part1.R
+++ b/tests/testthat/test-inflate-part1.R
@@ -28,6 +28,14 @@ usethis::with_project(dummypackage, {
 
   test_that("inflate() worked correctly", {
 
+    # Description with version
+    expect_true(file.exists(file.path(dummypackage, "DESCRIPTION")))
+    desc <- desc::desc(file.path(dummypackage, "DESCRIPTION"))
+    version_line <- desc$get("FusenVersion")
+    expect_equal(length(version_line), 1)
+    expect_equal(as.character(version_line),
+                 as.character(utils::packageVersion(pkg = "fusen")))
+
     # Number of files
     expect_equal(length(list.files(file.path(dummypackage, "R"))), 11)
     expect_equal(length(list.files(file.path(dummypackage, "vignettes"))), 1)


### PR DESCRIPTION
tags: feat, doc

Why?

- Next {fusen} version will come with big changes, the version number will be an index to trigger (or not) new functions

What?

- Add {fusen} version number in the DESCRIPTION file

issue #24