### PR TITLE
Use of unexported usethis functions

### DIFF
--- a/R/inflate.R
+++ b/R/inflate.R
@@ -620,9 +620,10 @@ create_vignette <- function(parsed_tbl, pkg, relative_flat_file, vignette_name, 
   yaml_options <- flat_yaml[["ast"]][[1]]
   # Vignette
   # Copied from usethis::use_vignette() to allow to not open vignette created
-  # usethis:::use_dependency("knitr", "Suggests")
-  getFromNamespace("use_dependency", "usethis")("knitr", "Suggests")
-  getFromNamespace("use_description_field", "usethis")("VignetteBuilder", "knitr", overwrite = TRUE)
+  usethis::use_package("knitr", "Suggests")
+  desc <- desc::desc(file = usethis::proj_get())
+  desc$set("VignetteBuilder", "knitr")
+  desc$write()
   usethis::use_git_ignore("inst/doc")
 
   # Vignette head


### PR DESCRIPTION
We are [currently preparing a release of usethis](https://github.com/r-lib/usethis/issues/1849), and noticed in our reverse dependency checks that we have removed an unexported function (`use_description_field`) that you were using via `getFromNamespace()`. This causes a failure in checking fusen.

As I'm sure you know, using unexported functions from packages you don't maintain is a bit risky as they are susceptible to change.

This PR includes a change to use the `desc` package (which fusen already imports) to achieve the same result as using `use_description_field()`. I also replaced the use of `usethis:::use_dependency()` with `use_package()`, which is the user-facing function that is intended for this purpose.

I hope this is helpful! We plan to release usethis in the next couple of days.

