### PR TITLE
fix: Allow "." for current package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,6 +50,7 @@ VignetteBuilder:
 Config/fusen/version: 0.5.1
 Config/Needs/website: ThinkR-open/thinkrtemplate
 Config/testthat/edition: 3
+Config/testthat/parallel: true
 Encoding: UTF-8
 Language: en-US
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Suggests:
     withr
 VignetteBuilder: 
     knitr
-Config/fusen/version: 0.5.0.9011
+Config/fusen/version: 0.5.1
 Config/Needs/website: ThinkR-open/thinkrtemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New features
 
-- Allow a styler function with parameter `stylers` in `inflate_all*()` 
+- Allow a styler function with parameter `stylers` in `inflate_all*()` (e.g `inflate_all(stylers = styler::style_pkg)`)
 
 ## Minor changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# fusen 0.5.2
+
+## New features
+
+- Allow a styler function with parameter `stylers` in `inflate_all*()` 
+
+## Minor changes
+
+- Fix use of `packageVersion()` with character
+- Allow "." for current package when adding flat file without DESCRIPTION (#224)
+
 # fusen 0.5.1
 
 ## New features

--- a/R/add_flat_template.R
+++ b/R/add_flat_template.R
@@ -85,12 +85,12 @@ add_dev_history <- function(pkg = ".",
 }
 
 flat_template_choices <- c(
-    "full",
-    "minimal_package", "minpkg",
-    "minimal_flat", "minflat", "add", "additional",
-    "teach", "teaching",
-    "dev_history", "dev"
-  )
+  "full",
+  "minimal_package", "minpkg",
+  "minimal_flat", "minflat", "add", "additional",
+  "teach", "teaching",
+  "dev_history", "dev"
+)
 
 create_fusen_choices <- c("full", "minimal", "teaching", "dev_history")
 

--- a/R/add_flat_template.R
+++ b/R/add_flat_template.R
@@ -84,6 +84,16 @@ add_dev_history <- function(pkg = ".",
   )
 }
 
+flat_template_choices <- c(
+    "full",
+    "minimal_package", "minpkg",
+    "minimal_flat", "minflat", "add", "additional",
+    "teach", "teaching",
+    "dev_history", "dev"
+  )
+
+create_fusen_choices <- c("full", "minimal", "teaching", "dev_history")
+
 #' Add flat Rmd file that drives package development
 #'
 #' @param template Name of the template to use. See details.
@@ -162,13 +172,7 @@ add_flat_template <- function(template = c("full", "minimal_package", "minimal_f
   }
 
   template <- template[1]
-  template <- match.arg(template, choices = c(
-    "full",
-    "minimal_package", "minpkg",
-    "minimal_flat", "minflat", "add", "additional",
-    "teach", "teaching",
-    "dev_history", "dev"
-  ))
+  template <- match.arg(template, choices = flat_template_choices)
 
   if (template %in% c("additional", "add")) {
     template <- "additional"

--- a/R/create_fusen_rsproject.R
+++ b/R/create_fusen_rsproject.R
@@ -27,7 +27,7 @@ create_fusen <- function(path,
                          overwrite = FALSE,
                          with_git = FALSE) {
   path <- normalizePath(path, mustWork = FALSE)
-  template <- match.arg(template)
+  template <- match.arg(template, choices = create_fusen_choices)
 
   project_name <- get_pkg_name(pkg = path)
   if (project_name != asciify_name(project_name, to_pkg = TRUE)) {

--- a/R/inflate-utils.R
+++ b/R/inflate-utils.R
@@ -440,7 +440,7 @@ get_pkg_name <- function(pkg) {
   if (file.exists(desc)) {
     pkgname <- read.dcf(desc)[colnames(read.dcf(desc)) == "Package"]
   } else {
-    pkgname <- basename(pkg)
+    pkgname <- basename(normalizePath(pkg, mustWork = FALSE))
   }
   pkgname
 }

--- a/R/init_share_on_github.R
+++ b/R/init_share_on_github.R
@@ -7,11 +7,11 @@
 #'
 #' @param ask Logical. `TRUE` (default) to ask the user to apply the instructions each time needed,
 #' or `FALSE` if the user already know what to do.
-#' 
+#'
 #' @details
-#' 
+#'
 #' `init_share_on_github()` runs multiple steps to be able to share a proper package on GitHub:
-#' 
+#'
 #' - Start versionning with git if not already
 #' - Connect to your GitHub account
 #' - Create a minimal DESCRIPTION file if missing
@@ -24,7 +24,7 @@
 #' - Init continuous deployment (CD) of the {pkgdown} website documentation
 #' - Commit and push to GitHub
 #' - List remaining manual steps to make the website public
-#' 
+#'
 #' Read `vignette("share-on-a-github-website", package = "fusen")`
 #'
 #' @return The URL of the website created

--- a/R/register_config_file.R
+++ b/R/register_config_file.R
@@ -372,7 +372,7 @@ df_to_config <- function(df_files,
           yaml_paths[!all_exists],
           collapse = ", "
         ), ".\n",
-        "Please open the configuration file: ", config_file," to verify, and delete the non-existing files if needed."
+        "Please open the configuration file: ", config_file, " to verify, and delete the non-existing files if needed."
       )
       if (isTRUE(force)) {
         cli_alert_warning(

--- a/R/register_config_file.R
+++ b/R/register_config_file.R
@@ -367,11 +367,12 @@ df_to_config <- function(df_files,
     all_exists <- file.exists(yaml_paths)
     if (!all(all_exists)) {
       msg <- paste(
-        "Some 'path' in config_file do not exist:",
+        "Some paths in config_file do not exist:",
         paste(
           yaml_paths[!all_exists],
           collapse = ", "
-        )
+        ), ".\n",
+        "Please open the configuration file: ", config_file," to verify, and delete the non-existing files if needed."
       )
       if (isTRUE(force)) {
         cli_alert_warning(

--- a/dev/config_fusen.yaml
+++ b/dev/config_fusen.yaml
@@ -28,11 +28,9 @@ flat_history_core.Rmd:
   path: dev/flat_history_core.Rmd
   state: inactive
   R:
-  - R/add_dev_history.R
   - R/fill_description.R
   - R/inflate.R
   tests:
-  - tests/testthat/test-add_dev_history.R
   - tests/testthat/test-fill_description.R
   - tests/testthat/test-inflate-part1.R
   - tests/testthat/test-inflate-part2.R
@@ -101,6 +99,7 @@ flat_register_config_file.Rmd:
     overwrite: 'yes'
 keep:
   path: keep
+  state: active
   R:
   - R/addins.R
   - R/create_fusen_rsproject.R
@@ -110,6 +109,7 @@ keep:
   - R/load_flat_functions.R
   - R/utils-pipe.R
   tests:
+  - tests/testthat/test-user-story.R
   - tests/testthat/test-create_fusen_rsproject.R
   - tests/testthat/test-inflate_qmd.R
   - tests/testthat/test-inflate_utils.R

--- a/dev/dev_history.R
+++ b/dev/dev_history.R
@@ -24,11 +24,13 @@ my_desc$set_version("0.0.0.9000")
 my_desc$set(Package = "fusen")
 my_desc$set(Title = "Build A Package From Rmarkdown file")
 my_desc$set(Description = "Use Rmd First method to build your package. Start your package with documentation. Everything can be set from a Rmarkdown file in your project.")
-my_desc$set("Authors@R",
-            'c(
+my_desc$set(
+  "Authors@R",
+  'c(
   person("Sebastien", "Rochette", email = "sebastien@thinkr.fr", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-1565-9313")),
   person(given = "ThinkR", role = "cph")
-)')
+)'
+)
 my_desc$set("VignetteBuilder", "knitr")
 my_desc$del("Maintainer")
 my_desc$del("URL")
@@ -98,20 +100,27 @@ usethis::use_build_ignore("_pkgdown.yml")
 fusen::inflate_all()
 fusen::inflate_all(args = c("--no-manual", "--no-tests"))
 fusen::inflate_all_no_check()
+fusen::inflate_all_no_check(stylers = function() {
+  styler::style_pkg()
+  styler::style_dir("dev")
+})
 
 # Clean style ----
 styler::style_pkg()
-styler::style_file(list.files("dev", pattern = "[.](Rmd|qmd|rmd)$", full.names = TRUE)
-)
+styler::style_file(list.files("dev", pattern = "[.](Rmd|qmd|rmd)$", full.names = TRUE))
 
 # Dependencies ----
 # devtools::install_github("ThinkR-open/attachment")
 # attachment::att_from_namespace()
 attachment::att_amend_desc(
-  pkg_ignore = c("testthat", "dummypackage", "rstudioapi",
-                 "knitr", "rmarkdown", "R6", "gert"),
-  extra.suggests = c("testthat", "pkgload", "rstudioapi",
-                     "rmarkdown", "knitr", "gert"),
+  pkg_ignore = c(
+    "testthat", "dummypackage", "rstudioapi",
+    "knitr", "rmarkdown", "R6", "gert"
+  ),
+  extra.suggests = c(
+    "testthat", "pkgload", "rstudioapi",
+    "rmarkdown", "knitr", "gert", "styler"
+  ),
   # "MASS", "lattice", "Matrix")
   update.config = TRUE # attachment >= 0.4.0.
 )
@@ -164,11 +173,13 @@ the_flat <- fusen::add_additional(
   pkg = skeleton_dir,
   dev_dir = "dev",
   flat_name = "skeleton",
-  open = TRUE)
+  open = TRUE
+)
 file.copy(
   the_flat,
   here::here("inst/rmarkdown/templates/additional/skeleton/skeleton.Rmd"),
-  overwrite = TRUE)
+  overwrite = TRUE
+)
 unlink(skeleton_dir, recursive = TRUE)
 
 # _Check in interactive test-inflate for templates and Addins ----
@@ -195,8 +206,8 @@ Sys.setenv("FUSEN_TEST_PUBLISH" = "FALSE")
 # Run examples in interactive mode too
 devtools::run_examples()
 
-local <- utils::fileSnapshot (".", timestamp = tempfile("timestamp"), md5sum = TRUE)
-home <- utils::fileSnapshot ("~", timestamp = tempfile("timestamp"), md5sum = TRUE)
+local <- utils::fileSnapshot(".", timestamp = tempfile("timestamp"), md5sum = TRUE)
+home <- utils::fileSnapshot("~", timestamp = tempfile("timestamp"), md5sum = TRUE)
 
 # run tests or whatever, then ...
 # x <- autotest::autotest_package(test = TRUE)
@@ -211,7 +222,7 @@ rcmdcheck::rcmdcheck(check_dir = dircheck)
 the_dir <- list.files(file.path(dircheck), pattern = ".Rcheck", full.names = TRUE)
 # Same tests, no new files
 all(list.files(file.path(the_dir, "tests", "testthat")) %in%
-list.files(file.path(".", "tests", "testthat")))
+  list.files(file.path(".", "tests", "testthat")))
 
 devtools::build_vignettes()
 devtools::clean_vignettes()

--- a/dev/dev_history.R
+++ b/dev/dev_history.R
@@ -159,6 +159,7 @@ usethis::pr_finish(41)
 # _Update template Rmd ----
 skeleton_dir <- tempfile()
 dir.create(skeleton_dir)
+# When opening, verify that "skeleton" is written in the correct places
 the_flat <- fusen::add_additional(
   pkg = skeleton_dir,
   dev_dir = "dev",

--- a/dev/flat_create_flat.Rmd
+++ b/dev/flat_create_flat.Rmd
@@ -15,6 +15,16 @@ library(tools)
 # add_flat_template
 
 ```{r function-1}
+flat_template_choices <- c(
+    "full",
+    "minimal_package", "minpkg",
+    "minimal_flat", "minflat", "add", "additional",
+    "teach", "teaching",
+    "dev_history", "dev"
+  )
+
+create_fusen_choices <- c("full", "minimal", "teaching", "dev_history")
+
 #' Add flat Rmd file that drives package development
 #'
 #' @param template Name of the template to use. See details.
@@ -65,13 +75,7 @@ add_flat_template <- function(template = c("full", "minimal_package", "minimal_f
   }
 
   template <- template[1]
-  template <- match.arg(template, choices = c(
-    "full",
-    "minimal_package", "minpkg",
-    "minimal_flat", "minflat", "add", "additional",
-    "teach", "teaching",
-    "dev_history", "dev"
-  ))
+  template <- match.arg(template, choices = flat_template_choices)
 
   if (template %in% c("additional", "add")) {
     template <- "additional"
@@ -438,13 +442,21 @@ unlink(dummypackage3, recursive = TRUE)
 # with the correct here()
 
 # Test all templates to knit ----
-all_templates <- c("full", "minimal_package", "additional", "teaching") # "dev_history"
+all_templates <- fusen:::flat_template_choices[!fusen:::flat_template_choices %in% c("dev_history", "dev")] # "dev_history"
+test_that("all templates to knit and inflate a second time", {
+  expect_length(all_templates, 9)
+})
 
 for (template in all_templates) {
   # template <- all_templates[1]
   main_flat_file_name <- template
-  if (template == "minimal_package") {
+  if (template %in% c("minimal_package", "minpkg", 
+                      "minimal_flat", "minflat")) {
     main_flat_file_name <- "minimal"
+  } else if (template == "add") {
+    main_flat_file_name <- "additional"
+  } else if (template == "teach") {
+    main_flat_file_name <- "teaching"
   }
 
   dummypackage4 <- tempfile(pattern = "all.templates.knit")
@@ -452,24 +464,54 @@ for (template in all_templates) {
   
   orig.proj <- here::here()
   
-    # Add
-  dev_file_path <- suppressMessages(add_flat_template(pkg = dummypackage4, template = template, open = FALSE))
+  withr::with_dir(dummypackage4, {
+
+    # Add template
+  dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
   flat_file <- dev_file_path[grepl("flat", dev_file_path)]
 
   # Change lines asking for pkg name
-  lines_template <- readLines(system.file("tests-templates/dev-template-tests.Rmd", package = "fusen"))
+  lines_template <- readLines(flat_file)
   lines_template[grepl("<my_package_name>", lines_template)] <-
     gsub(
       "<my_package_name>", basename(dummypackage4),
       lines_template[grepl("<my_package_name>", lines_template)]
     )
+  if (any(grepl("\\{r description", lines_template))) {
+    lines_template[grepl("\\{r description", lines_template)] <- "```{r description, eval=TRUE}"
+  }
   cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
+  
+  # description chunk as eval=TRUE
+  if (any(grepl("dev_history", dev_file_path))) {
+    dev_hist_path <- dev_file_path[grepl("dev_history", dev_file_path)]
+    lines_dev <- readLines(dev_hist_path)
+    lines_dev[grepl("\\{r description", lines_dev)] <- "```{r description, eval=TRUE}"
+    cat(enc2utf8(lines_dev), file = dev_hist_path, sep = "\n")
+  }
 
-withr::with_dir(dummypackage4, {
+  # Simulate as being inside project
     usethis::proj_set(dummypackage4)
     here:::do_refresh_here(dummypackage4)
     
     if (rmarkdown::pandoc_available("1.12.3")) {
+      # knitting with dev_history should transform project as a package
+      # as fill_description is eval = TRUE
+      if (any(grepl("dev_history", dev_file_path))) {
+
+        rmarkdown::render(
+          input = dev_hist_path,
+          output_file = file.path(dummypackage4, "dev", "dev_history.html"),
+          envir = new.env(), quiet = TRUE
+        )
+      } else if (template %in% c("additional", "add", 
+                                 "minimal_flat", "minflat")) {
+        fusen::fill_description(pkg = here::here(),
+                                fields = list(Title = "Dummy Package"))
+        # Define License with use_*_license()
+        usethis::use_mit_license("John Doe")
+      }
+      
       rmarkdown::render(
         input = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd")),
         output_file = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html")),
@@ -481,7 +523,7 @@ withr::with_dir(dummypackage4, {
     here:::do_refresh_here(orig.proj)
   })
 
-  test_that(paste0("template", template, "runs as markdown"), {
+  test_that(paste0("template", template, "runs as markdown and project is a package"), {
     expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd"))))
     if (template %in% c("full", "minimal_package")) {
       expect_true(file.exists(file.path(dirname(flat_file), "0-dev_history.Rmd")))
@@ -490,15 +532,37 @@ withr::with_dir(dummypackage4, {
     if (rmarkdown::pandoc_available("1.12.3")) {
       expect_true(file.exists(file.path(dummypackage4, "DESCRIPTION")))
       expect_true(file.exists(file.path(dummypackage4, "LICENSE")))
-      if (template %in% c("full", "teaching")) {
+      if (template %in% c("full")) {
         expect_true(file.exists(file.path(dummypackage4, "inst", "nyc_squirrels_sample.csv")))
+      } else {
+        expect_false(file.exists(file.path(dummypackage4, "inst", "nyc_squirrels_sample.csv")))
       }
       expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html"))))
     }
   })
+  
+  # Now try to inflate from the inflate chunk
+  test_that("flat file inflates after knit from command inside", {
+    flat_lines <- readLines(flat_file)
+    
+    expect_true(sum(grepl(paste0("fusen::inflate\\(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\""), flat_lines)) == 1)
+    
+    withr::with_dir(dummypackage4, {
+      inflate_command <- paste0("fusen::inflate(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\", open_vignette = FALSE, check = FALSE)")
+      expect_error(suppressMessages(eval(parse(text = inflate_command))), regexp = NA)
+    })
+  })
+  
+  # Now try to inflates a second time
+  test_that("flat file inflates a second time", {
+    withr::with_dir(dummypackage4, {
+      inflate_command_second <- paste0("fusen::inflate(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\", open_vignette = FALSE, check = FALSE, overwrite = TRUE)")
+      expect_error(suppressMessages(eval(parse(text = inflate_command_second))), regexp = NA)
+    })
+  })
+  
   unlink(dummypackage4, recursive = TRUE)
 } # end of loop on template knit
-
 
 # Test other names modifies template ----
 dummypackage <- tempfile(pattern = "other.names")

--- a/dev/flat_create_flat.Rmd
+++ b/dev/flat_create_flat.Rmd
@@ -390,7 +390,7 @@ test_that("add dev_history template works with windows \\users path", {
 
     expect_true(file.exists(dev_file_path))
     # Test specific \\users path
-    newdir_uu <- tempfile("aa\\U/gzv")
+    newdir_uu <- tempfile("aa\\Users/gzv")
     dir.create(newdir_uu, recursive = TRUE)
 
     usethis::with_project(dummypackage, {
@@ -450,8 +450,10 @@ test_that("all templates to knit and inflate a second time", {
 for (template in all_templates) {
   # template <- all_templates[1]
   main_flat_file_name <- template
-  if (template %in% c("minimal_package", "minpkg",
-                      "minimal_flat", "minflat")) {
+  if (template %in% c(
+    "minimal_package", "minpkg",
+    "minimal_flat", "minflat"
+  )) {
     main_flat_file_name <- "minimal"
   } else if (template == "add") {
     main_flat_file_name <- "additional"
@@ -467,40 +469,36 @@ for (template in all_templates) {
   withr::with_dir(dummypackage4, {
 
     # Add template
-  dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
-  flat_file <- dev_file_path[grepl("flat", dev_file_path)]
+    dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
+    flat_file <- dev_file_path[grepl("flat", dev_file_path)]
 
-  # Change lines asking for pkg name
-  lines_template <- readLines(flat_file)
-  lines_template[grepl("<my_package_name>", lines_template)] <-
-    gsub(
-      "<my_package_name>", basename(dummypackage4),
-      lines_template[grepl("<my_package_name>", lines_template)]
-    )
-  # Run description chunk to build DESCRIPTION file and make it a proper pkg
-  desc_line <- grep("\\{r description", lines_template)
-  if (length(desc_line) != 0) {
-    lines_template[desc_line] <- "```{r description, eval=TRUE}"
-  }
-  # pkgload::load_all in the template cannot work in non interactive R CMD Check
-  if (template == "full" & !interactive()) {
-    loadall_line <- grep("^pkgload::load_all", lines_template)
-    lines_template[loadall_line] <- "# pkgload::load_all() commented"
-    data_line <- grep("datafile <- system.file", lines_template)
-    lines_template[data_line] <- glue::glue('datafile <- file.path(normalize_path_winslash("{dummypackage4}"), "inst", "nyc_squirrels_sample.csv")')
-  }
+    lines_template <- readLines(flat_file)
+    # Run description chunk to build DESCRIPTION file and make it a proper pkg
+    desc_line <- grep("\\{r description", lines_template)
+    if (length(desc_line) != 0) {
+      lines_template[desc_line] <- "```{r description, eval=TRUE}"
+    }
+    # pkgload::load_all in the template cannot work in non interactive R CMD Check
+    if (template == "full" & !interactive()) {
+    # if (template == "full" & interactive()) {
+      loadall_line <- grep("^pkgload::load_all", lines_template)
+      lines_template[loadall_line] <- "# pkgload::load_all() commented"
+      data_line <- grep("datafile <- system.file", lines_template)
+      lines_template[data_line] <-
+        glue::glue('datafile <- file.path("{normalize_path_winslash(dummypackage4)}", "inst", "nyc_squirrels_sample.csv")')
+    }
 
-  cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
+    cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
 
-  # description chunk as eval=TRUE
-  if (any(grepl("dev_history", dev_file_path))) {
-    dev_hist_path <- dev_file_path[grepl("dev_history", dev_file_path)]
-    lines_dev <- readLines(dev_hist_path)
-    lines_dev[grepl("\\{r description", lines_dev)] <- "```{r description, eval=TRUE}"
-    cat(enc2utf8(lines_dev), file = dev_hist_path, sep = "\n")
-  }
+    # description chunk as eval=TRUE
+    if (any(grepl("dev_history", dev_file_path))) {
+      dev_hist_path <- dev_file_path[grepl("dev_history", dev_file_path)]
+      lines_dev <- readLines(dev_hist_path)
+      lines_dev[grepl("\\{r description", lines_dev)] <- "```{r description, eval=TRUE}"
+      cat(enc2utf8(lines_dev), file = dev_hist_path, sep = "\n")
+    }
 
-  # Simulate as being inside project
+    # Simulate as being inside project
     usethis::proj_set(dummypackage4)
     here:::do_refresh_here(dummypackage4)
 
@@ -514,12 +512,18 @@ for (template in all_templates) {
               input = dev_hist_path,
               output_file = file.path(dummypackage4, "dev", "dev_history.html"),
               envir = new.env(), quiet = TRUE
-            ), regexp = NA)
+            ),
+            regexp = NA
+          )
         })
-      } else if (template %in% c("additional", "add",
-                                 "minimal_flat", "minflat")) {
-        fusen::fill_description(pkg = here::here(),
-                                fields = list(Title = "Dummy Package"))
+      } else if (template %in% c(
+        "additional", "add",
+        "minimal_flat", "minflat"
+      )) {
+        fusen::fill_description(
+          pkg = here::here(),
+          fields = list(Title = "Dummy Package")
+        )
         # Define License with use_*_license()
         usethis::use_mit_license("John Doe")
       }
@@ -533,7 +537,9 @@ for (template in all_templates) {
             input = flat_to_render,
             output_file = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html")),
             envir = new.env(), quiet = TRUE
-          ), regexp = NA)
+          ),
+          regexp = NA
+        )
       })
     }
 
@@ -741,6 +747,7 @@ test_that("add_flat_template allows bad flat_name for function name with add", {
   expect_equal(length(grep("bad_for_function_but_ok2", dev_lines)), 8)
 })
 unlink(dummypackage, recursive = TRUE)
+
 ```
 
 ## add_additional & co.

--- a/dev/flat_create_flat.Rmd
+++ b/dev/flat_create_flat.Rmd
@@ -487,7 +487,7 @@ for (template in all_templates) {
     loadall_line <- grep("^pkgload::load_all", lines_template)
     lines_template[loadall_line] <- "# pkgload::load_all() commented"
     data_line <- grep("datafile <- system.file", lines_template)
-    lines_template[data_line] <- glue::glue('datafile <- file.path("inst", "nyc_squirrels_sample.csv")')
+    lines_template[data_line] <- glue::glue('datafile <- file.path(normalize_path_winslash("{dummypackage4}"), "inst", "nyc_squirrels_sample.csv")')
   }
 
   cat(enc2utf8(lines_template), file = flat_file, sep = "\n")

--- a/dev/flat_create_flat.Rmd
+++ b/dev/flat_create_flat.Rmd
@@ -477,9 +477,19 @@ for (template in all_templates) {
       "<my_package_name>", basename(dummypackage4),
       lines_template[grepl("<my_package_name>", lines_template)]
     )
-  if (any(grepl("\\{r description", lines_template))) {
-    lines_template[grepl("\\{r description", lines_template)] <- "```{r description, eval=TRUE}"
+  # Run description chunk to build DESCRIPTION file and make it a proper pkg
+  desc_line <- grep("\\{r description", lines_template)
+  if (length(desc_line) != 0) {
+    lines_template[desc_line] <- "```{r description, eval=TRUE}"
   }
+  # pkgload::load_all in the template cannot work in non interactive R CMD Check
+  if (template == "full" & !interactive()) {
+    loadall_line <- grep("^pkgload::load_all", lines_template)
+    lines_template[loadall_line] <- "# pkgload::load_all() commented"
+    data_line <- grep("datafile <- system.file", lines_template)
+    lines_template[data_line] <- glue::glue('datafile <- file.path("{dummypackage4}", "inst", "nyc_squirrels_sample.csv")')
+  }
+
   cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
 
   # description chunk as eval=TRUE
@@ -514,10 +524,13 @@ for (template in all_templates) {
         usethis::use_mit_license("John Doe")
       }
 
-      test_that(paste0("template", template, "can be rendered"), {
+      test_that(paste0("template ", template, " can be rendered"), {
+        flat_to_render <- file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd"))
+        expect_true(file.exists(flat_to_render))
+
         expect_error(
           rmarkdown::render(
-            input = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd")),
+            input = flat_to_render,
             output_file = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html")),
             envir = new.env(), quiet = TRUE
           ), regexp = NA)

--- a/dev/flat_create_flat.Rmd
+++ b/dev/flat_create_flat.Rmd
@@ -487,7 +487,7 @@ for (template in all_templates) {
     loadall_line <- grep("^pkgload::load_all", lines_template)
     lines_template[loadall_line] <- "# pkgload::load_all() commented"
     data_line <- grep("datafile <- system.file", lines_template)
-    lines_template[data_line] <- glue::glue('datafile <- file.path("{dummypackage4}", "inst", "nyc_squirrels_sample.csv")')
+    lines_template[data_line] <- glue::glue('datafile <- file.path("inst", "nyc_squirrels_sample.csv")')
   }
 
   cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
@@ -541,7 +541,7 @@ for (template in all_templates) {
     here:::do_refresh_here(orig.proj)
   })
 
-  test_that(paste0("template", template, "that was run as Rmarkdown gives project as a package"), {
+  test_that(paste0("template ", template, " that was run as Rmarkdown gives project as a package"), {
     expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd"))))
     if (template %in% c("full", "minimal_package")) {
       expect_true(file.exists(file.path(dirname(flat_file), "0-dev_history.Rmd")))

--- a/dev/flat_create_flat.Rmd
+++ b/dev/flat_create_flat.Rmd
@@ -16,12 +16,12 @@ library(tools)
 
 ```{r function-1}
 flat_template_choices <- c(
-    "full",
-    "minimal_package", "minpkg",
-    "minimal_flat", "minflat", "add", "additional",
-    "teach", "teaching",
-    "dev_history", "dev"
-  )
+  "full",
+  "minimal_package", "minpkg",
+  "minimal_flat", "minflat", "add", "additional",
+  "teach", "teaching",
+  "dev_history", "dev"
+)
 
 create_fusen_choices <- c("full", "minimal", "teaching", "dev_history")
 
@@ -467,7 +467,6 @@ for (template in all_templates) {
   orig.proj <- here::here()
 
   withr::with_dir(dummypackage4, {
-
     # Add template
     dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
     flat_file <- dev_file_path[grepl("flat", dev_file_path)]
@@ -480,7 +479,7 @@ for (template in all_templates) {
     }
     # pkgload::load_all in the template cannot work in non interactive R CMD Check
     if (template == "full" & !interactive()) {
-    # if (template == "full" & interactive()) {
+      # if (template == "full" & interactive()) {
       loadall_line <- grep("^pkgload::load_all", lines_template)
       lines_template[loadall_line] <- "# pkgload::load_all() commented"
       data_line <- grep("datafile <- system.file", lines_template)
@@ -747,7 +746,6 @@ test_that("add_flat_template allows bad flat_name for function name with add", {
   expect_equal(length(grep("bad_for_function_but_ok2", dev_lines)), 8)
 })
 unlink(dummypackage, recursive = TRUE)
-
 ```
 
 ## add_additional & co.

--- a/dev/flat_create_flat.Rmd
+++ b/dev/flat_create_flat.Rmd
@@ -450,7 +450,7 @@ test_that("all templates to knit and inflate a second time", {
 for (template in all_templates) {
   # template <- all_templates[1]
   main_flat_file_name <- template
-  if (template %in% c("minimal_package", "minpkg", 
+  if (template %in% c("minimal_package", "minpkg",
                       "minimal_flat", "minflat")) {
     main_flat_file_name <- "minimal"
   } else if (template == "add") {
@@ -461,9 +461,9 @@ for (template in all_templates) {
 
   dummypackage4 <- tempfile(pattern = "all.templates.knit")
   dir.create(dummypackage4)
-  
+
   orig.proj <- here::here()
-  
+
   withr::with_dir(dummypackage4, {
 
     # Add template
@@ -481,7 +481,7 @@ for (template in all_templates) {
     lines_template[grepl("\\{r description", lines_template)] <- "```{r description, eval=TRUE}"
   }
   cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
-  
+
   # description chunk as eval=TRUE
   if (any(grepl("dev_history", dev_file_path))) {
     dev_hist_path <- dev_file_path[grepl("dev_history", dev_file_path)]
@@ -493,37 +493,42 @@ for (template in all_templates) {
   # Simulate as being inside project
     usethis::proj_set(dummypackage4)
     here:::do_refresh_here(dummypackage4)
-    
+
     if (rmarkdown::pandoc_available("1.12.3")) {
       # knitting with dev_history should transform project as a package
       # as fill_description is eval = TRUE
       if (any(grepl("dev_history", dev_file_path))) {
-
-        rmarkdown::render(
-          input = dev_hist_path,
-          output_file = file.path(dummypackage4, "dev", "dev_history.html"),
-          envir = new.env(), quiet = TRUE
-        )
-      } else if (template %in% c("additional", "add", 
+        test_that(paste0("dev_history can be rendered, associated with template", template), {
+          expect_error(
+            rmarkdown::render(
+              input = dev_hist_path,
+              output_file = file.path(dummypackage4, "dev", "dev_history.html"),
+              envir = new.env(), quiet = TRUE
+            ), regexp = NA)
+        })
+      } else if (template %in% c("additional", "add",
                                  "minimal_flat", "minflat")) {
         fusen::fill_description(pkg = here::here(),
                                 fields = list(Title = "Dummy Package"))
         # Define License with use_*_license()
         usethis::use_mit_license("John Doe")
       }
-      
-      rmarkdown::render(
-        input = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd")),
-        output_file = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html")),
-        envir = new.env(), quiet = TRUE
-      )
+
+      test_that(paste0("template", template, "can be rendered"), {
+        expect_error(
+          rmarkdown::render(
+            input = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd")),
+            output_file = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html")),
+            envir = new.env(), quiet = TRUE
+          ), regexp = NA)
+      })
     }
-    
+
     usethis::proj_set(NULL)
     here:::do_refresh_here(orig.proj)
   })
 
-  test_that(paste0("template", template, "runs as markdown and project is a package"), {
+  test_that(paste0("template", template, "that was run as Rmarkdown gives project as a package"), {
     expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd"))))
     if (template %in% c("full", "minimal_package")) {
       expect_true(file.exists(file.path(dirname(flat_file), "0-dev_history.Rmd")))
@@ -540,19 +545,19 @@ for (template in all_templates) {
       expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html"))))
     }
   })
-  
+
   # Now try to inflate from the inflate chunk
   test_that("flat file inflates after knit from command inside", {
     flat_lines <- readLines(flat_file)
-    
+
     expect_true(sum(grepl(paste0("fusen::inflate\\(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\""), flat_lines)) == 1)
-    
+
     withr::with_dir(dummypackage4, {
       inflate_command <- paste0("fusen::inflate(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\", open_vignette = FALSE, check = FALSE)")
       expect_error(suppressMessages(eval(parse(text = inflate_command))), regexp = NA)
     })
   })
-  
+
   # Now try to inflates a second time
   test_that("flat file inflates a second time", {
     withr::with_dir(dummypackage4, {
@@ -560,7 +565,7 @@ for (template in all_templates) {
       expect_error(suppressMessages(eval(parse(text = inflate_command_second))), regexp = NA)
     })
   })
-  
+
   unlink(dummypackage4, recursive = TRUE)
 } # end of loop on template knit
 

--- a/dev/flat_inflate_all.Rmd
+++ b/dev/flat_inflate_all.Rmd
@@ -62,6 +62,7 @@ Note also that all files stored in R, tests and vignettes directories are checke
 #'
 #' @param pkg Path to package
 #' @param clean Logical. Whether to help detect unregistered files.
+#' @param stylers Function to be run at the end of the process, like `styler::style_pkg` or `lintr::lint_package` or a lambda function combining functions like: `function() {styler::style_pkg(); lintr::lint_package()}`. For a unique function, use the format without parenthesis `()` at the end of the command.
 #' @inheritParams inflate
 #'
 #' @importFrom yaml read_yaml
@@ -82,7 +83,7 @@ Note also that all files stored in R, tests and vignettes directories are checke
 #'   [register_all_to_config()] for automatically registering all files already present in the project before the first `inflate_all()`
 #'
 #' @export
-inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, ...) {
+inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, stylers, ...) {
   config_file <- getOption("fusen.config_file", default = "dev/config_fusen.yaml")
 
   if (!file.exists(config_file)) {
@@ -140,27 +141,39 @@ inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette 
     }
 
     apply_inflate(inflate_params, pkg = pkg, overwrite = overwrite, open_vignette = open_vignette)
-
-    # Document and check package
-    document_and_check_pkg(
-      pkg = pkg,
-      check = check,
-      document = document,
-      ...
-    )
   }
 
   if (isTRUE(clean)) {
     cli::cat_rule("check not registered files")
     invisible(check_not_registered_files(path = pkg))
   }
+
+  if (!missing(stylers)) {
+    cli::cat_rule("Let's apply stylers to the package")
+    if (is.function(stylers)) {
+      stylers()
+    } else if (is.character(stylers)) {
+      eval(parse(text = stylers))
+    } else {
+      stylers
+    }
+  }
+
+  # Document and check package
+  document_and_check_pkg(
+    pkg = pkg,
+    check = check,
+    document = document,
+    ...
+  )
+
   invisible(pkg)
 }
 
 #' @rdname inflate_all
 #' @export
-inflate_all_no_check <- function(pkg = ".", document = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, ...) {
-  inflate_all(pkg = pkg, document = document, check = FALSE, open_vignette = open_vignette, overwrite = overwrite, clean = clean, ...)
+inflate_all_no_check <- function(pkg = ".", document = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, stylers, ...) {
+  inflate_all(pkg = pkg, document = document, check = FALSE, open_vignette = open_vignette, overwrite = overwrite, clean = clean, stylers, ...)
 }
 ```
   
@@ -171,6 +184,8 @@ inflate_all_no_check <- function(pkg = ".", document = TRUE, open_vignette = FAL
 inflate_all()
 # Or inflate_all_no_check() to prevent checks to run
 inflate_all_no_check()
+# Or inflate with the styler you want
+inflate_all(stylers = styler::style_pkg)
 #' }
 
 # You can also inflate_all flats of another package as follows
@@ -467,7 +482,7 @@ unlink(dummypackage, recursive = TRUE)
 # Example with a dummy package with a flat file
 dummypackage <- tempfile("inflateall")
 dir.create(dummypackage)
-fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
 flat_files <- add_minimal_package(
   pkg = dummypackage,
   overwrite = TRUE,
@@ -481,17 +496,19 @@ file.rename(flat_file, flat_file_newname)
 # Inflate the flat file once
 usethis::with_project(dummypackage, {
   # Add licence
-  usethis::use_mit_license("John Doe")
+  suppressMessages(usethis::use_mit_license("John Doe"))
 
   # you need to inflate manually your flat file first
-  inflate(
-    pkg = dummypackage,
-    flat_file = flat_file_newname,
-    vignette_name = "Get started",
-    check = FALSE,
-    open_vignette = FALSE,
-    document = TRUE,
-    overwrite = "yes"
+  suppressMessages(
+    inflate(
+      pkg = dummypackage,
+      flat_file = flat_file_newname,
+      vignette_name = "Get started",
+      check = FALSE,
+      open_vignette = FALSE,
+      document = TRUE,
+      overwrite = "yes"
+    )
   )
 
   # your config file has been created
@@ -521,7 +538,7 @@ unlink(dummypackage, recursive = TRUE)
 # Test inflate_all_no_check vs inflate_all with check ----
 dummypackage <- tempfile("inflateall")
 dir.create(dummypackage)
-fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
 dev_file <- suppressMessages(add_minimal_package(pkg = dummypackage, overwrite = TRUE, open = FALSE))
 
 # let's create a flat file
@@ -533,7 +550,7 @@ test_that("inflate_all_no_check is a function", {
 
 usethis::with_project(dummypackage, {
   # Add licence
-  usethis::use_mit_license("John Doe")
+  suppressMessages(usethis::use_mit_license("John Doe"))
 
   suppressMessages(
     inflate(
@@ -588,7 +605,7 @@ unlink(dummypackage, recursive = TRUE)
 # Test inflate_all detects unregistered files ----
 dummypackage <- tempfile("inflateall.unregistered")
 dir.create(dummypackage)
-fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
 dev_file <- suppressMessages(add_minimal_package(pkg = dummypackage, overwrite = TRUE, open = FALSE))
 
 flat_file <- dev_file[grepl("flat_", dev_file)]
@@ -725,7 +742,7 @@ usethis::with_project(dummypackage, {
     flat_file,
     overwrite = TRUE
   )
-  usethis::use_mit_license("Statnmap")
+  suppressMessages(usethis::use_mit_license("Statnmap"))
 
   suppressMessages(
     inflate(
@@ -825,6 +842,51 @@ usethis::with_project(dummypackage, {
     expect_false(file.exists(file.path(dummypackage, "vignettes", "get-started.Rmd")))
     expect_false(dir.exists(file.path(dummypackage, "R")))
     expect_false(dir.exists(file.path(dummypackage, "tests")))
+  })
+})
+unlink(dummypackage, recursive = TRUE)
+
+# Test inflate_all works with stylers ----
+dummypackage <- tempfile("inflateall.stylers")
+dir.create(dummypackage)
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
+dev_file <- suppressMessages(add_minimal_package(pkg = dummypackage, overwrite = TRUE, open = FALSE))
+
+flat_file <- dev_file[grepl("flat_", dev_file)]
+
+usethis::with_project(dummypackage, {
+  # Add licence
+  suppressMessages(usethis::use_mit_license("John Doe"))
+
+  suppressMessages(
+    inflate(
+      pkg = dummypackage,
+      flat_file = flat_file,
+      vignette_name = "toto",
+      check = FALSE,
+      open_vignette = FALSE,
+      document = TRUE,
+      overwrite = "yes"
+    )
+  )
+
+  # Check that stylers work ----
+  test_that("stylers works in inflate_all", {
+    # as character
+    expect_message(
+      inflate_all_no_check(stylers = "message('stylers ok')"),
+      regexp = "stylers ok"
+    )
+    # as function
+    expect_message(
+      inflate_all_no_check(stylers = function() message("stylers ok")),
+      regexp = "stylers ok"
+    )
+    # as other - run during `if()` call, but that's normal...
+    expect_message(
+      inflate_all_no_check(stylers = message("stylers ok")),
+      regexp = "stylers ok"
+    )
   })
 })
 ```

--- a/dev/flat_init_share_on_github.Rmd
+++ b/dev/flat_init_share_on_github.Rmd
@@ -74,11 +74,11 @@ fusen::inflate(flat_file = "dev/flat_full.Rmd", vignette_name = "Get started")
 #'
 #' @param ask Logical. `TRUE` (default) to ask the user to apply the instructions each time needed,
 #' or `FALSE` if the user already know what to do.
-#' 
+#'
 #' @details
-#' 
+#'
 #' `init_share_on_github()` runs multiple steps to be able to share a proper package on GitHub:
-#' 
+#'
 #' - Start versionning with git if not already
 #' - Connect to your GitHub account
 #' - Create a minimal DESCRIPTION file if missing
@@ -91,7 +91,7 @@ fusen::inflate(flat_file = "dev/flat_full.Rmd", vignette_name = "Get started")
 #' - Init continuous deployment (CD) of the {pkgdown} website documentation
 #' - Commit and push to GitHub
 #' - List remaining manual steps to make the website public
-#' 
+#'
 #' Read `vignette("share-on-a-github-website", package = "fusen")`
 #'
 #' @return The URL of the website created

--- a/dev/flat_register_config_file.Rmd
+++ b/dev/flat_register_config_file.Rmd
@@ -965,7 +965,7 @@ df_to_config <- function(df_files,
           yaml_paths[!all_exists],
           collapse = ", "
         ), ".\n",
-        "Please open the configuration file: ", config_file," to verify, and delete the non-existing files if needed."
+        "Please open the configuration file: ", config_file, " to verify, and delete the non-existing files if needed."
       )
       if (isTRUE(force)) {
         cli_alert_warning(

--- a/dev/flat_register_config_file.Rmd
+++ b/dev/flat_register_config_file.Rmd
@@ -748,7 +748,7 @@ usethis::with_project(dummypackage, {
     config_file <- yaml::read_yaml("dev/config_fusen.yaml")
     expect_error(
       register_all_to_config(),
-      regexp = "Some 'path' in config_file do not exist: R/my_old_fun.R"
+      regexp = "Some paths in config_file do not exist: R/my_old_fun.R"
     )
 
     # Clean the missing file and it should be good to add the second new file
@@ -960,11 +960,12 @@ df_to_config <- function(df_files,
     all_exists <- file.exists(yaml_paths)
     if (!all(all_exists)) {
       msg <- paste(
-        "Some 'path' in config_file do not exist:",
+        "Some paths in config_file do not exist:",
         paste(
           yaml_paths[!all_exists],
           collapse = ", "
-        )
+        ), ".\n",
+        "Please open the configuration file: ", config_file," to verify, and delete the non-existing files if needed."
       )
       if (isTRUE(force)) {
         cli_alert_warning(

--- a/inst/the-dev-history.Rmd
+++ b/inst/the-dev-history.Rmd
@@ -11,7 +11,7 @@ All commands that you use to use when developing packages...
 
 - Fill the following chunk to create the DESCRIPTION of your package
 
-```{r description, eval=FALSE}
+```{r description}
 # Describe your package
 fusen::fill_description(
   pkg = here::here(),
@@ -94,7 +94,7 @@ gitlabr::use_gitlab_ci(type = "check-coverage-pkgdown")
 
 ## Use everytime needed
 
-```{r}
+```{r, eval=FALSE}
 # Simulate package installation
 pkgload::load_all()
 
@@ -110,7 +110,7 @@ fusen::add_flat_template("add")
 
 # Share the package
 
-```{r}
+```{r, eval=FALSE}
 # set and try pkgdown documentation website locally
 usethis::use_pkgdown()
 pkgdown::build_site()

--- a/man/inflate_all.Rd
+++ b/man/inflate_all.Rd
@@ -12,6 +12,7 @@ inflate_all(
   open_vignette = FALSE,
   overwrite = TRUE,
   clean = TRUE,
+  stylers,
   ...
 )
 
@@ -21,6 +22,7 @@ inflate_all_no_check(
   open_vignette = FALSE,
   overwrite = TRUE,
   clean = TRUE,
+  stylers,
   ...
 )
 }
@@ -37,6 +39,8 @@ inflate_all_no_check(
 Whether to overwrite vignette and functions if already exists.}
 
 \item{clean}{Logical. Whether to help detect unregistered files.}
+
+\item{stylers}{Function to be run at the end of the process, like \code{styler::style_pkg} or \code{lintr::lint_package} or a lambda function combining functions like: \code{function() {styler::style_pkg(); lintr::lint_package()}}. For a unique function, use the format without parenthesis \verb{()} at the end of the command.}
 
 \item{...}{Arguments passed to \code{devtools::check()}.
 For example, you can do \code{inflate(check = TRUE, quiet = TRUE)}, where \code{quiet} is
@@ -62,6 +66,8 @@ For more information, read the \code{vignette("inflate-all-your-flat-files", pac
 inflate_all()
 # Or inflate_all_no_check() to prevent checks to run
 inflate_all_no_check()
+# Or inflate with the styler you want
+inflate_all(stylers = styler::style_pkg)
 }
 
 # You can also inflate_all flats of another package as follows

--- a/tests/testthat/test-add_flat_template.R
+++ b/tests/testthat/test-add_flat_template.R
@@ -468,7 +468,6 @@ test_that("add_flat_template allows bad flat_name for function name with add", {
 })
 unlink(dummypackage, recursive = TRUE)
 
-
 # add_full ----
 dummypackage <- tempfile(pattern = "add.wrappers")
 dir.create(dummypackage)

--- a/tests/testthat/test-add_flat_template.R
+++ b/tests/testthat/test-add_flat_template.R
@@ -171,8 +171,10 @@ test_that("all templates to knit and inflate a second time", {
 for (template in all_templates) {
   # template <- all_templates[1]
   main_flat_file_name <- template
-  if (template %in% c("minimal_package", "minpkg",
-                      "minimal_flat", "minflat")) {
+  if (template %in% c(
+    "minimal_package", "minpkg",
+    "minimal_flat", "minflat"
+  )) {
     main_flat_file_name <- "minimal"
   } else if (template == "add") {
     main_flat_file_name <- "additional"
@@ -186,42 +188,41 @@ for (template in all_templates) {
   orig.proj <- here::here()
 
   withr::with_dir(dummypackage4, {
-
     # Add template
-  dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
-  flat_file <- dev_file_path[grepl("flat", dev_file_path)]
+    dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
+    flat_file <- dev_file_path[grepl("flat", dev_file_path)]
 
-  # Change lines asking for pkg name
-  lines_template <- readLines(flat_file)
-  lines_template[grepl("<my_package_name>", lines_template)] <-
-    gsub(
-      "<my_package_name>", basename(dummypackage4),
-      lines_template[grepl("<my_package_name>", lines_template)]
-    )
-  # Run description chunk to build DESCRIPTION file and make it a proper pkg
-  desc_line <- grep("\\{r description", lines_template)
-  if (length(desc_line) != 0) {
-    lines_template[desc_line] <- "```{r description, eval=TRUE}"
-  }
-  # pkgload::load_all in the template cannot work in non interactive R CMD Check
-  if (template == "full" & !interactive()) {
-    loadall_line <- grep("^pkgload::load_all", lines_template)
-    lines_template[loadall_line] <- "# pkgload::load_all() commented"
-    data_line <- grep("datafile <- system.file", lines_template)
-    lines_template[data_line] <- glue::glue('datafile <- file.path("inst", "nyc_squirrels_sample.csv")')
-  }
+    # Change lines asking for pkg name
+    lines_template <- readLines(flat_file)
+    lines_template[grepl("<my_package_name>", lines_template)] <-
+      gsub(
+        "<my_package_name>", basename(dummypackage4),
+        lines_template[grepl("<my_package_name>", lines_template)]
+      )
+    # Run description chunk to build DESCRIPTION file and make it a proper pkg
+    desc_line <- grep("\\{r description", lines_template)
+    if (length(desc_line) != 0) {
+      lines_template[desc_line] <- "```{r description, eval=TRUE}"
+    }
+    # pkgload::load_all in the template cannot work in non interactive R CMD Check
+    if (template == "full" & !interactive()) {
+      loadall_line <- grep("^pkgload::load_all", lines_template)
+      lines_template[loadall_line] <- "# pkgload::load_all() commented"
+      data_line <- grep("datafile <- system.file", lines_template)
+      lines_template[data_line] <- glue::glue('datafile <- file.path(normalize_path_winslash("{dummypackage4}"), "inst", "nyc_squirrels_sample.csv")')
+    }
 
-  cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
+    cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
 
-  # description chunk as eval=TRUE
-  if (any(grepl("dev_history", dev_file_path))) {
-    dev_hist_path <- dev_file_path[grepl("dev_history", dev_file_path)]
-    lines_dev <- readLines(dev_hist_path)
-    lines_dev[grepl("\\{r description", lines_dev)] <- "```{r description, eval=TRUE}"
-    cat(enc2utf8(lines_dev), file = dev_hist_path, sep = "\n")
-  }
+    # description chunk as eval=TRUE
+    if (any(grepl("dev_history", dev_file_path))) {
+      dev_hist_path <- dev_file_path[grepl("dev_history", dev_file_path)]
+      lines_dev <- readLines(dev_hist_path)
+      lines_dev[grepl("\\{r description", lines_dev)] <- "```{r description, eval=TRUE}"
+      cat(enc2utf8(lines_dev), file = dev_hist_path, sep = "\n")
+    }
 
-  # Simulate as being inside project
+    # Simulate as being inside project
     usethis::proj_set(dummypackage4)
     here:::do_refresh_here(dummypackage4)
 
@@ -235,12 +236,18 @@ for (template in all_templates) {
               input = dev_hist_path,
               output_file = file.path(dummypackage4, "dev", "dev_history.html"),
               envir = new.env(), quiet = TRUE
-            ), regexp = NA)
+            ),
+            regexp = NA
+          )
         })
-      } else if (template %in% c("additional", "add",
-                                 "minimal_flat", "minflat")) {
-        fusen::fill_description(pkg = here::here(),
-                                fields = list(Title = "Dummy Package"))
+      } else if (template %in% c(
+        "additional", "add",
+        "minimal_flat", "minflat"
+      )) {
+        fusen::fill_description(
+          pkg = here::here(),
+          fields = list(Title = "Dummy Package")
+        )
         # Define License with use_*_license()
         usethis::use_mit_license("John Doe")
       }
@@ -254,7 +261,9 @@ for (template in all_templates) {
             input = flat_to_render,
             output_file = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html")),
             envir = new.env(), quiet = TRUE
-          ), regexp = NA)
+          ),
+          regexp = NA
+        )
       })
     }
 

--- a/tests/testthat/test-add_flat_template.R
+++ b/tests/testthat/test-add_flat_template.R
@@ -208,7 +208,7 @@ for (template in all_templates) {
     loadall_line <- grep("^pkgload::load_all", lines_template)
     lines_template[loadall_line] <- "# pkgload::load_all() commented"
     data_line <- grep("datafile <- system.file", lines_template)
-    lines_template[data_line] <- glue::glue('datafile <- file.path("{dummypackage4}", "inst", "nyc_squirrels_sample.csv")')
+    lines_template[data_line] <- glue::glue('datafile <- file.path("inst", "nyc_squirrels_sample.csv")')
   }
 
   cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
@@ -262,7 +262,7 @@ for (template in all_templates) {
     here:::do_refresh_here(orig.proj)
   })
 
-  test_that(paste0("template", template, "that was run as Rmarkdown gives project as a package"), {
+  test_that(paste0("template ", template, " that was run as Rmarkdown gives project as a package"), {
     expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd"))))
     if (template %in% c("full", "minimal_package")) {
       expect_true(file.exists(file.path(dirname(flat_file), "0-dev_history.Rmd")))

--- a/tests/testthat/test-add_flat_template.R
+++ b/tests/testthat/test-add_flat_template.R
@@ -111,7 +111,7 @@ test_that("add dev_history template works with windows \\users path", {
 
     expect_true(file.exists(dev_file_path))
     # Test specific \\users path
-    newdir_uu <- tempfile("aa\\U/gzv")
+    newdir_uu <- tempfile("aa\\Users/gzv")
     dir.create(newdir_uu, recursive = TRUE)
 
     usethis::with_project(dummypackage, {
@@ -192,13 +192,7 @@ for (template in all_templates) {
     dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
     flat_file <- dev_file_path[grepl("flat", dev_file_path)]
 
-    # Change lines asking for pkg name
     lines_template <- readLines(flat_file)
-    lines_template[grepl("<my_package_name>", lines_template)] <-
-      gsub(
-        "<my_package_name>", basename(dummypackage4),
-        lines_template[grepl("<my_package_name>", lines_template)]
-      )
     # Run description chunk to build DESCRIPTION file and make it a proper pkg
     desc_line <- grep("\\{r description", lines_template)
     if (length(desc_line) != 0) {
@@ -206,10 +200,12 @@ for (template in all_templates) {
     }
     # pkgload::load_all in the template cannot work in non interactive R CMD Check
     if (template == "full" & !interactive()) {
+      # if (template == "full" & interactive()) {
       loadall_line <- grep("^pkgload::load_all", lines_template)
       lines_template[loadall_line] <- "# pkgload::load_all() commented"
       data_line <- grep("datafile <- system.file", lines_template)
-      lines_template[data_line] <- glue::glue('datafile <- file.path(normalize_path_winslash("{dummypackage4}"), "inst", "nyc_squirrels_sample.csv")')
+      lines_template[data_line] <-
+        glue::glue('datafile <- file.path("{normalize_path_winslash(dummypackage4)}", "inst", "nyc_squirrels_sample.csv")')
     }
 
     cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
@@ -471,6 +467,7 @@ test_that("add_flat_template allows bad flat_name for function name with add", {
   expect_equal(length(grep("bad_for_function_but_ok2", dev_lines)), 8)
 })
 unlink(dummypackage, recursive = TRUE)
+
 
 # add_full ----
 dummypackage <- tempfile(pattern = "add.wrappers")

--- a/tests/testthat/test-add_flat_template.R
+++ b/tests/testthat/test-add_flat_template.R
@@ -163,13 +163,21 @@ unlink(dummypackage3, recursive = TRUE)
 # with the correct here()
 
 # Test all templates to knit ----
-all_templates <- c("full", "minimal_package", "additional", "teaching") # "dev_history"
+all_templates <- fusen:::flat_template_choices[!fusen:::flat_template_choices %in% c("dev_history", "dev")] # "dev_history"
+test_that("all templates to knit and inflate a second time", {
+  expect_length(all_templates, 9)
+})
 
 for (template in all_templates) {
   # template <- all_templates[1]
   main_flat_file_name <- template
-  if (template == "minimal_package") {
+  if (template %in% c("minimal_package", "minpkg", 
+                      "minimal_flat", "minflat")) {
     main_flat_file_name <- "minimal"
+  } else if (template == "add") {
+    main_flat_file_name <- "additional"
+  } else if (template == "teach") {
+    main_flat_file_name <- "teaching"
   }
 
   dummypackage4 <- tempfile(pattern = "all.templates.knit")
@@ -177,24 +185,54 @@ for (template in all_templates) {
   
   orig.proj <- here::here()
   
-    # Add
-  dev_file_path <- suppressMessages(add_flat_template(pkg = dummypackage4, template = template, open = FALSE))
+  withr::with_dir(dummypackage4, {
+
+    # Add template
+  dev_file_path <- suppressMessages(add_flat_template(template = template, open = FALSE))
   flat_file <- dev_file_path[grepl("flat", dev_file_path)]
 
   # Change lines asking for pkg name
-  lines_template <- readLines(system.file("tests-templates/dev-template-tests.Rmd", package = "fusen"))
+  lines_template <- readLines(flat_file)
   lines_template[grepl("<my_package_name>", lines_template)] <-
     gsub(
       "<my_package_name>", basename(dummypackage4),
       lines_template[grepl("<my_package_name>", lines_template)]
     )
+  if (any(grepl("\\{r description", lines_template))) {
+    lines_template[grepl("\\{r description", lines_template)] <- "```{r description, eval=TRUE}"
+  }
   cat(enc2utf8(lines_template), file = flat_file, sep = "\n")
+  
+  # description chunk as eval=TRUE
+  if (any(grepl("dev_history", dev_file_path))) {
+    dev_hist_path <- dev_file_path[grepl("dev_history", dev_file_path)]
+    lines_dev <- readLines(dev_hist_path)
+    lines_dev[grepl("\\{r description", lines_dev)] <- "```{r description, eval=TRUE}"
+    cat(enc2utf8(lines_dev), file = dev_hist_path, sep = "\n")
+  }
 
-withr::with_dir(dummypackage4, {
+  # Simulate as being inside project
     usethis::proj_set(dummypackage4)
     here:::do_refresh_here(dummypackage4)
     
     if (rmarkdown::pandoc_available("1.12.3")) {
+      # knitting with dev_history should transform project as a package
+      # as fill_description is eval = TRUE
+      if (any(grepl("dev_history", dev_file_path))) {
+
+        rmarkdown::render(
+          input = dev_hist_path,
+          output_file = file.path(dummypackage4, "dev", "dev_history.html"),
+          envir = new.env(), quiet = TRUE
+        )
+      } else if (template %in% c("additional", "add", 
+                                 "minimal_flat", "minflat")) {
+        fusen::fill_description(pkg = here::here(),
+                                fields = list(Title = "Dummy Package"))
+        # Define License with use_*_license()
+        usethis::use_mit_license("John Doe")
+      }
+      
       rmarkdown::render(
         input = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd")),
         output_file = file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html")),
@@ -206,7 +244,7 @@ withr::with_dir(dummypackage4, {
     here:::do_refresh_here(orig.proj)
   })
 
-  test_that(paste0("template", template, "runs as markdown"), {
+  test_that(paste0("template", template, "runs as markdown and project is a package"), {
     expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".Rmd"))))
     if (template %in% c("full", "minimal_package")) {
       expect_true(file.exists(file.path(dirname(flat_file), "0-dev_history.Rmd")))
@@ -215,15 +253,37 @@ withr::with_dir(dummypackage4, {
     if (rmarkdown::pandoc_available("1.12.3")) {
       expect_true(file.exists(file.path(dummypackage4, "DESCRIPTION")))
       expect_true(file.exists(file.path(dummypackage4, "LICENSE")))
-      if (template %in% c("full", "teaching")) {
+      if (template %in% c("full")) {
         expect_true(file.exists(file.path(dummypackage4, "inst", "nyc_squirrels_sample.csv")))
+      } else {
+        expect_false(file.exists(file.path(dummypackage4, "inst", "nyc_squirrels_sample.csv")))
       }
       expect_true(file.exists(file.path(dummypackage4, "dev", paste0("flat_", main_flat_file_name, ".html"))))
     }
   })
+  
+  # Now try to inflate from the inflate chunk
+  test_that("flat file inflates after knit from command inside", {
+    flat_lines <- readLines(flat_file)
+    
+    expect_true(sum(grepl(paste0("fusen::inflate\\(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\""), flat_lines)) == 1)
+    
+    withr::with_dir(dummypackage4, {
+      inflate_command <- paste0("fusen::inflate(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\", open_vignette = FALSE, check = FALSE)")
+      expect_error(suppressMessages(eval(parse(text = inflate_command))), regexp = NA)
+    })
+  })
+  
+  # Now try to inflates a second time
+  test_that("flat file inflates a second time", {
+    withr::with_dir(dummypackage4, {
+      inflate_command_second <- paste0("fusen::inflate(flat_file = \"dev/flat_", main_flat_file_name, ".Rmd\", open_vignette = FALSE, check = FALSE, overwrite = TRUE)")
+      expect_error(suppressMessages(eval(parse(text = inflate_command_second))), regexp = NA)
+    })
+  })
+  
   unlink(dummypackage4, recursive = TRUE)
 } # end of loop on template knit
-
 
 # Test other names modifies template ----
 dummypackage <- tempfile(pattern = "other.names")

--- a/tests/testthat/test-create_fusen_rsproject.R
+++ b/tests/testthat/test-create_fusen_rsproject.R
@@ -66,7 +66,6 @@ unlink(dummypackage, recursive = TRUE)
 ## Create a new project
 
 for (template.to.try in fusen:::create_fusen_choices) {
-
   # template.to.try <- "full"
   dummypackage <- tempfile(pattern = paste0("create.fusen.", template.to.try))
   dir.create(dummypackage)
@@ -75,7 +74,6 @@ for (template.to.try in fusen:::create_fusen_choices) {
 
   withr::with_dir(dummypackage, {
     test_that(paste("Create fusen works with template:", template.to.try), {
-
       if (template.to.try %in% "dev_history") {
         expected_rmd_template_with_fusen_name <- NULL
       } else {
@@ -86,11 +84,13 @@ for (template.to.try in fusen:::create_fusen_choices) {
 
         expect_message(
           expected_rmd_template_with_fusen_name <- readLines(
-            system.file(paste0("flat-template-", template.to.try.rmd, ".Rmd"), package = "fusen")) %>%
+            system.file(paste0("flat-template-", template.to.try.rmd, ".Rmd"), package = "fusen")
+          ) %>%
             gsub("<my_package_name>", pkgname, .) %>%
-            gsub("flat_template[.]Rmd", paste0("flat_",flat_name,".Rmd"), .) %>%
+            gsub("flat_template[.]Rmd", paste0("flat_", flat_name, ".Rmd"), .) %>%
             gsub("my_fun", flat_name, .),
-          regexp = NA)
+          regexp = NA
+        )
       }
 
       path_foosen <- file.path(dummypackage, pkgname)
@@ -98,7 +98,8 @@ for (template.to.try in fusen:::create_fusen_choices) {
       expect_error(
         path_dev_history <- suppressMessages(
           create_fusen(path_foosen, template = template.to.try, flat_name = flat_name, open = FALSE)
-        ), regexp = NA
+        ),
+        regexp = NA
       )
 
       expect_true(dir.exists(path_foosen))
@@ -158,7 +159,6 @@ for (template.to.try in c("full", "minimal", "teaching", "dev_history")) {
   dummygui <- create_dummygui()
   withr::with_dir(dummygui$dirname, {
     test_that(paste("Can create in a project with gui for:", template.to.try), {
-
       dev_path <- expect_error(
         suppressMessages(
           create_fusen_gui(dummygui$basename, template = template.to.try, with_git = FALSE)

--- a/tests/testthat/test-create_fusen_rsproject.R
+++ b/tests/testthat/test-create_fusen_rsproject.R
@@ -65,7 +65,7 @@ unlink(dummypackage, recursive = TRUE)
 # Test other templates with different flat_name ----
 ## Create a new project
 
-for (template.to.try in c("full", "minimal", "teaching", "dev_history")) {
+for (template.to.try in fusen:::create_fusen_choices) {
 
   # template.to.try <- "full"
   dummypackage <- tempfile(pattern = paste0("create.fusen.", template.to.try))

--- a/tests/testthat/test-inflate-part2.R
+++ b/tests/testthat/test-inflate-part2.R
@@ -53,7 +53,9 @@ unlink(dummypackage, recursive = TRUE)
 alltemp <- tempfile("all.templates.inflate")
 dir.create(alltemp)
 
-for (pkgname in c("full", "teaching", "minimal")) {
+# for (pkgname in c("full", "teaching", "minimal")) {
+create_choices_test <- fusen:::create_fusen_choices[!grepl("dev_history", fusen:::create_fusen_choices)]
+for (pkgname in create_choices_test) {
   # No "additional" with create_fusen
   # {fusen} steps
   path_foosen <- normalize_path_winslash(file.path(alltemp, pkgname), mustWork = FALSE)

--- a/tests/testthat/test-inflate_all.R
+++ b/tests/testthat/test-inflate_all.R
@@ -246,7 +246,7 @@ unlink(dummypackage, recursive = TRUE)
 # Example with a dummy package with a flat file
 dummypackage <- tempfile("inflateall")
 dir.create(dummypackage)
-fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
 flat_files <- add_minimal_package(
   pkg = dummypackage,
   overwrite = TRUE,
@@ -260,17 +260,19 @@ file.rename(flat_file, flat_file_newname)
 # Inflate the flat file once
 usethis::with_project(dummypackage, {
   # Add licence
-  usethis::use_mit_license("John Doe")
+  suppressMessages(usethis::use_mit_license("John Doe"))
 
   # you need to inflate manually your flat file first
-  inflate(
-    pkg = dummypackage,
-    flat_file = flat_file_newname,
-    vignette_name = "Get started",
-    check = FALSE,
-    open_vignette = FALSE,
-    document = TRUE,
-    overwrite = "yes"
+  suppressMessages(
+    inflate(
+      pkg = dummypackage,
+      flat_file = flat_file_newname,
+      vignette_name = "Get started",
+      check = FALSE,
+      open_vignette = FALSE,
+      document = TRUE,
+      overwrite = "yes"
+    )
   )
 
   # your config file has been created
@@ -300,7 +302,7 @@ unlink(dummypackage, recursive = TRUE)
 # Test inflate_all_no_check vs inflate_all with check ----
 dummypackage <- tempfile("inflateall")
 dir.create(dummypackage)
-fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
 dev_file <- suppressMessages(add_minimal_package(pkg = dummypackage, overwrite = TRUE, open = FALSE))
 
 # let's create a flat file
@@ -312,7 +314,7 @@ test_that("inflate_all_no_check is a function", {
 
 usethis::with_project(dummypackage, {
   # Add licence
-  usethis::use_mit_license("John Doe")
+  suppressMessages(usethis::use_mit_license("John Doe"))
 
   suppressMessages(
     inflate(
@@ -367,7 +369,7 @@ unlink(dummypackage, recursive = TRUE)
 # Test inflate_all detects unregistered files ----
 dummypackage <- tempfile("inflateall.unregistered")
 dir.create(dummypackage)
-fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
 dev_file <- suppressMessages(add_minimal_package(pkg = dummypackage, overwrite = TRUE, open = FALSE))
 
 flat_file <- dev_file[grepl("flat_", dev_file)]
@@ -504,7 +506,7 @@ usethis::with_project(dummypackage, {
     flat_file,
     overwrite = TRUE
   )
-  usethis::use_mit_license("Statnmap")
+  suppressMessages(usethis::use_mit_license("Statnmap"))
 
   suppressMessages(
     inflate(
@@ -604,5 +606,50 @@ usethis::with_project(dummypackage, {
     expect_false(file.exists(file.path(dummypackage, "vignettes", "get-started.Rmd")))
     expect_false(dir.exists(file.path(dummypackage, "R")))
     expect_false(dir.exists(file.path(dummypackage, "tests")))
+  })
+})
+unlink(dummypackage, recursive = TRUE)
+
+# Test inflate_all works with stylers ----
+dummypackage <- tempfile("inflateall.stylers")
+dir.create(dummypackage)
+suppressMessages(fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package")))
+dev_file <- suppressMessages(add_minimal_package(pkg = dummypackage, overwrite = TRUE, open = FALSE))
+
+flat_file <- dev_file[grepl("flat_", dev_file)]
+
+usethis::with_project(dummypackage, {
+  # Add licence
+  suppressMessages(usethis::use_mit_license("John Doe"))
+
+  suppressMessages(
+    inflate(
+      pkg = dummypackage,
+      flat_file = flat_file,
+      vignette_name = "toto",
+      check = FALSE,
+      open_vignette = FALSE,
+      document = TRUE,
+      overwrite = "yes"
+    )
+  )
+
+  # Check that stylers work ----
+  test_that("stylers works in inflate_all", {
+    # as character
+    expect_message(
+      inflate_all_no_check(stylers = "message('stylers ok')"),
+      regexp = "stylers ok"
+    )
+    # as function
+    expect_message(
+      inflate_all_no_check(stylers = function() message("stylers ok")),
+      regexp = "stylers ok"
+    )
+    # as other - run during `if()` call, but that's normal...
+    expect_message(
+      inflate_all_no_check(stylers = message("stylers ok")),
+      regexp = "stylers ok"
+    )
   })
 })

--- a/tests/testthat/test-inflate_qmd.R
+++ b/tests/testthat/test-inflate_qmd.R
@@ -8,7 +8,7 @@ dev_file <- suppressMessages(add_flat_template(pkg = dummypackage, overwrite = T
 flat_file <- dev_file[grepl("flat_", dev_file)]
 
 # For comments with #|
-skip_if_not(utils::packageVersion("knitr") >= 1.35)
+skip_if_not(utils::packageVersion("knitr") >= "1.35")
 
 usethis::with_project(dummypackage, {
   # More complicated example for tests

--- a/tests/testthat/test-register_config_file.R
+++ b/tests/testthat/test-register_config_file.R
@@ -312,7 +312,7 @@ usethis::with_project(dummypackage, {
     config_file <- yaml::read_yaml("dev/config_fusen.yaml")
     expect_error(
       register_all_to_config(),
-      regexp = "Some 'path' in config_file do not exist: R/my_old_fun.R"
+      regexp = "Some paths in config_file do not exist: R/my_old_fun.R"
     )
 
     # Clean the missing file and it should be good to add the second new file

--- a/tests/testthat/test-user-story.R
+++ b/tests/testthat/test-user-story.R
@@ -23,15 +23,19 @@ for (template in all_templates_second) {
 
     # Follow dev_history
     suppressMessages(
-      fill_description(pkg = here::here(),
-                       fields = list(Title = "Dummy Package"))
+      fill_description(
+        pkg = here::here(),
+        fields = list(Title = "Dummy Package")
+      )
     )
     # Define License with use_*_license()
     suppressMessages(usethis::use_mit_license("John Doe"))
 
     # Inflate first flat file
-    suppressMessages(inflate(flat_file = "dev/flat_first.Rmd", vignette_name = "My First",
-                             open_vignette = FALSE, check = FALSE))
+    suppressMessages(inflate(
+      flat_file = "dev/flat_first.Rmd", vignette_name = "My First",
+      open_vignette = FALSE, check = FALSE
+    ))
 
     test_that(paste0("full process -", template, "- first minimal basis ok"), {
       expect_true(file.exists("DESCRIPTION"))
@@ -47,12 +51,15 @@ for (template in all_templates_second) {
     test_that(paste0("full process -", template, "- add and inflate new template"), {
       expect_error(
         add_flat_template(template = template, flat_name = "second", open = FALSE),
-        regexp = NA)
+        regexp = NA
+      )
       expect_true(file.exists("dev/flat_second.Rmd"))
 
       # Inflate second flat file
-      suppressMessages(inflate(flat_file = "dev/flat_second.Rmd", vignette_name = "My Second",
-                               open_vignette = FALSE, check = FALSE))
+      suppressMessages(inflate(
+        flat_file = "dev/flat_second.Rmd", vignette_name = "My Second",
+        open_vignette = FALSE, check = FALSE
+      ))
       expect_true(file.exists("vignettes/my-second.Rmd"))
 
 

--- a/tests/testthat/test-user-story.R
+++ b/tests/testthat/test-user-story.R
@@ -1,0 +1,86 @@
+# Test users full classical process ----
+all_templates_second <- fusen:::flat_template_choices[!fusen:::flat_template_choices %in% c("dev_history", "dev")]
+test_that("create_fusen and use it as users do", {
+  expect_length(all_templates_second, 9)
+})
+
+for (template in all_templates_second) {
+  # template <- all_templates_second[3]
+  dummypackage <- tempfile(pattern = "all.templates.second.flat")
+  dir.create(dummypackage)
+
+  path_foosen <- file.path(dummypackage, "foosen.process")
+
+  # Create new fusen project
+  paths_dev_history <- suppressMessages(
+    create_fusen(path_foosen, template = "minimal", flat_name = "first", open = FALSE)
+  )
+
+  orig.proj <- here::here()
+  # Now should be inside a project
+  usethis::with_project(path_foosen, {
+    here:::do_refresh_here(path_foosen)
+
+    # Follow dev_history
+    suppressMessages(
+      fill_description(pkg = here::here(),
+                       fields = list(Title = "Dummy Package"))
+    )
+    # Define License with use_*_license()
+    suppressMessages(usethis::use_mit_license("John Doe"))
+
+    # Inflate first flat file
+    suppressMessages(inflate(flat_file = "dev/flat_first.Rmd", vignette_name = "My First",
+                             open_vignette = FALSE, check = FALSE))
+
+    test_that(paste0("full process -", template, "- first minimal basis ok"), {
+      expect_true(file.exists("DESCRIPTION"))
+      expect_true(file.exists("dev/flat_first.Rmd"))
+      expect_true(file.exists("R/first.R"))
+      expect_true(file.exists("man/first.Rd"))
+      expect_true(file.exists("tests/testthat/test-first.R"))
+      expect_true(file.exists("vignettes/my-first.Rmd"))
+      expect_true(file.exists("NAMESPACE"))
+    })
+
+    # Add a new flat file with new function
+    test_that(paste0("full process -", template, "- add and inflate new template"), {
+      expect_error(
+        add_flat_template(template = template, flat_name = "second", open = FALSE),
+        regexp = NA)
+      expect_true(file.exists("dev/flat_second.Rmd"))
+
+      # Inflate second flat file
+      suppressMessages(inflate(flat_file = "dev/flat_second.Rmd", vignette_name = "My Second",
+                               open_vignette = FALSE, check = FALSE))
+      expect_true(file.exists("vignettes/my-second.Rmd"))
+
+
+      # Depends on template
+      if (template %in% c("full")) {
+        expect_true(file.exists("R/my_median.R"))
+        expect_true(file.exists("man/my_median.Rd"))
+        expect_true(file.exists("tests/testthat/test-my_median.R"))
+      } else if (template %in% c("teach", "teaching")) {
+        expect_true(file.exists("R/add_one.R"))
+        expect_true(file.exists("man/add_one.Rd"))
+        expect_true(file.exists("tests/testthat/test-add_one.R"))
+      } else {
+        expect_true(file.exists("R/second.R"))
+        expect_true(file.exists("man/second.Rd"))
+        expect_true(file.exists("tests/testthat/test-second.R"))
+      }
+    })
+
+    # inflate_all
+    test_that(paste0("full process -", template, "- inflate_all x2"), {
+      expect_error(suppressMessages(inflate_all_no_check()), regexp = NA)
+      expect_error(suppressMessages(inflate_all_no_check()), regexp = NA)
+    })
+
+    here:::do_refresh_here(orig.proj)
+  })
+
+
+  unlink(dummypackage, recursive = TRUE)
+} # end of loop on template knit

--- a/vignettes/inflate-all-your-flat-files.Rmd
+++ b/vignettes/inflate-all-your-flat-files.Rmd
@@ -73,6 +73,8 @@ Note also that all files stored in R, tests and vignettes directories are checke
 inflate_all()
 # Or inflate_all_no_check() to prevent checks to run
 inflate_all_no_check()
+# Or inflate with the styler you want
+inflate_all(stylers = styler::style_pkg)
 #' }
 
 # You can also inflate_all flats of another package as follows


### PR DESCRIPTION
tags: fix, test

- Add user test to verify that a classical user workflow works as expected
- Fix problem with `add_flat_template()` where current project was not recognised as proper package name
- Add a vector of values to be used to test all templates so that unit tests are up-to-date with new templates

issue #224