### PR TITLE
Clean obsolete files during inflate when possible

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Suggests:
     rmarkdown,
     rstudioapi,
     styler,
-    testthat (>= 3.0.0),
+    testthat (>= 3.2.0),
     withr
 VignetteBuilder: 
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 
 ## New features
 
+- `inflate()` detects functions renamed or removed and allow to clean the package repository (#24)
 - Allow `organisation` in `init_share_on_github()` to send to a GitHub organisation
 - Fix `load_flat_functions()` to work with VSCode
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Breaking changes
 
 - {fusen} now relies on {lightparser} instead of {parsermd} to parse flat file. This allows to avoid installation problems with {parsermd}, which is not updated anymore. As {lightparser} is lighter, this may have unattended effects on specific flat file cases. Please report any issue you may encounter. (#233)
+- `inflate_all*()` does not use parameter `clean` anymore. Use `check_unregistered` instead to check if all files are registered in the configuration file.
 
 ## New features
 

--- a/R/fill_description.R
+++ b/R/fill_description.R
@@ -77,5 +77,5 @@ fill_description <- function(pkg = ".", fields, overwrite = FALSE) {
 
   desc$write(file = desc_file)
 
-  desc_file
+  invisible(desc_file)
 }

--- a/R/inflate.R
+++ b/R/inflate.R
@@ -104,9 +104,9 @@ inflate <- function(pkg = ".", flat_file,
           "With vignette name: ", vignette_name, "\n",
           "Are you sure this is what you planned? (y/n)\n"
         )
-        do_it <- readline(sure) == "y"
+        do_it <- readline(sure) == "y" || readline(sure) == "yes"
       } else {
-        do_it <- isTRUE(overwrite)
+        do_it <- isTRUE(overwrite) || overwrite == "yes"
       }
       if (do_it) {
         message(

--- a/R/inflate_all.R
+++ b/R/inflate_all.R
@@ -5,8 +5,14 @@
 #' Inflate all the flat files stored in "dev/" and starting with "flat_"
 #'
 #' @param pkg Path to package
-#' @param clean Logical. Whether to help detect unregistered files.
-#' @param stylers Function to be run at the end of the process, like `styler::style_pkg` or `lintr::lint_package` or a lambda function combining functions like: `function() {styler::style_pkg(); lintr::lint_package()}`. For a unique function, use the format without parenthesis `()` at the end of the command.
+#' @param check_unregistered Logical. Whether to help detect unregistered files.
+#' Typically files not created from a flat file and added manually in the repository.
+#' @param stylers Function to be run at the end of the process,
+#' like `styler::style_pkg` or `lintr::lint_package`
+#' or a lambda function combining functions like:
+#' `function() {styler::style_pkg(); lintr::lint_package()}`.
+#' For a unique function, use the format without parenthesis `()`
+#' at the end of the command.
 #' @inheritParams inflate
 #'
 #' @importFrom yaml read_yaml
@@ -15,16 +21,26 @@
 #'
 #' @return side effect. Inflates all your flat files that can be inflated.
 #'
-#' @details This requires to [inflate()] all flat files individually at least once, so that their specific inflate configurations are stored.
+#' @details This requires to [inflate()] all flat files
+#'  individually at least once, so that their specific
+#'  inflate configurations are stored.
 #'
-#' This also requires to register all R, tests and vignettes files of your package, even if not created with an inflate. Run [inflate_all()] once and read the messages. The first time, you will probably need to run [register_all_to_config()] if your package is not new.
+#' This also requires to register all R,
+#'  tests and vignettes files of your package,
+#' even if not created with an inflate.
+#' Run [inflate_all()] once and read the messages.
+#' The first time, you will probably need to run
+#' [register_all_to_config()] if your package is not new.
 #'
-#' For more information, read the `vignette("inflate-all-your-flat-files", package = "fusen")`
+#' For more information, read the
+#'  `vignette("inflate-all-your-flat-files", package = "fusen")`
 #'
 #' @seealso
 #'   [inflate()] for the options of a single file inflate,
-#'   [check_not_registered_files()] for the list of files not already associated with a flat file in the config file,
-#'   [register_all_to_config()] for automatically registering all files already present in the project before the first `inflate_all()`
+#'   [check_not_registered_files()] for the list of files
+#' not already associated with a flat file in the config file,
+#'   [register_all_to_config()] for automatically registering
+#' all files already present in the project before the first `inflate_all()`
 #'
 #' @export
 #' @examples
@@ -83,7 +99,14 @@
 #'
 #' # Clean the temporary directory
 #' unlink(dummypackage, recursive = TRUE)
-inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, stylers, ...) {
+inflate_all <- function(
+    pkg = ".",
+    document = TRUE,
+    check = TRUE,
+    open_vignette = FALSE,
+    overwrite = TRUE,
+    check_unregistered = TRUE,
+    stylers, ...) {
   config_file <- getOption("fusen.config_file", default = "dev/config_fusen.yaml")
 
   if (!file.exists(config_file)) {
@@ -120,7 +143,9 @@ inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette 
     message("No flat files were inflated")
   } else {
     apply_inflate <- function(inflate_params, pkg, overwrite, open_vignette) {
-      config_file <- getOption("fusen.config_file", default = "dev/config_fusen.yaml")
+      config_file <- getOption("fusen.config_file",
+        default = "dev/config_fusen.yaml"
+      )
       # Change config option temporary, to be able to modify it on the fly
       config_file_tmp <- tempfile(pattern = "tempconfig")
       on.exit(file.remove(config_file_tmp))
@@ -140,10 +165,13 @@ inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette 
       )
     }
 
-    apply_inflate(inflate_params, pkg = pkg, overwrite = overwrite, open_vignette = open_vignette)
+    apply_inflate(inflate_params,
+      pkg = pkg, overwrite = overwrite,
+      open_vignette = open_vignette
+    )
   }
 
-  if (isTRUE(clean)) {
+  if (isTRUE(check_unregistered)) {
     cli::cat_rule("check not registered files")
     invisible(check_not_registered_files(path = pkg))
   }
@@ -172,6 +200,6 @@ inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette 
 
 #' @rdname inflate_all
 #' @export
-inflate_all_no_check <- function(pkg = ".", document = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, stylers, ...) {
-  inflate_all(pkg = pkg, document = document, check = FALSE, open_vignette = open_vignette, overwrite = overwrite, clean = clean, stylers, ...)
+inflate_all_no_check <- function(pkg = ".", document = TRUE, open_vignette = FALSE, overwrite = TRUE, check_unregistered = TRUE, stylers, ...) {
+  inflate_all(pkg = pkg, document = document, check = FALSE, open_vignette = open_vignette, overwrite = overwrite, check_unregistered = check_unregistered, stylers, ...)
 }

--- a/R/register_config_file.R
+++ b/R/register_config_file.R
@@ -466,8 +466,7 @@ df_to_config <- function(df_files,
   if (length(all_modified) != 0) {
     cli_alert_info(
       paste0(
-        "Some files group already existed and were ",
-        ifelse(isTRUE(clean), "overwritten: ", "modified: "),
+        "Some files group already existed and were modified: ",
         paste(all_modified, collapse = ", ")
       )
     )

--- a/R/register_config_file.R
+++ b/R/register_config_file.R
@@ -203,13 +203,20 @@ get_list_paths <- function(config_list) {
 #' @param df_files A data.frame with 'type' and 'path' columns
 #' or a csv file path as issued from `[check_not_registered_files()]`
 #' or nothing (and it will take the csv file in "dev/")
-#' @param flat_file_path Character. Usually set to `"keep"` for users. You can use the name of the origin flat file but this is more of an internal use, as inflating the flat file should have the same result.
+#' @param flat_file_path Character. Usually set to `"keep"` for users.
+#' You can use the name of the origin flat file but this is more of
+#' an internal use, as inflating the flat file should have the same result.
 #' @param state Character. Whether if the flat file is `active` or `deprecated`.
-#' @param force Logical. Whether to force writing the configuration file even is some files do not exist.
-#' @param clean Logical. Delete list associated to a specific flat file before updating the whole list.
-#' Default is set to TRUE during `inflate()` of a specific flat file, as the list should only contain files created during the inflate.
-#' This could be set to FALSE with a direct use of `df_to_config()` too. This is forced to FALSE for "keep" section.
-#' @param inflate_parameters list of parameters passed through a call to `inflate()`
+#' @param force Logical. Whether to force writing the configuration
+#' file even is some files do not exist.
+#' @param clean Logical (TRUE, FALSE) or character ("ask", "yes", "no).
+#' Whether to delete files created in a previous version of this flat file
+#' Default is set to "ask" during `inflate()` of a specific flat file,
+#' as the list should only contain files created during the inflate.
+#' This could be set to FALSE with a direct use of `df_to_config()` too.
+#' This is forced to FALSE for the "keep" section.
+#' @param inflate_parameters list of parameters passed through
+#' a call to `inflate()`
 
 #' @importFrom stats setNames
 #' @importFrom utils read.csv
@@ -219,8 +226,10 @@ get_list_paths <- function(config_list) {
 #' Side effect: create a yaml config file.
 #'
 #' @seealso
-#'   [check_not_registered_files()] for the list of files not already associated with a flat file in the config file,
-#'   [register_all_to_config()] for automatically registering all files already present in the project
+#'   [check_not_registered_files()] for the list of files not already
+#'  associated with a flat file in the config file,
+#'   [register_all_to_config()] for automatically registering
+#'  all files already present in the project
 #'
 #' @noRd
 
@@ -228,9 +237,12 @@ df_to_config <- function(df_files,
                          flat_file_path = "keep",
                          state = c("active", "deprecated"),
                          force = FALSE,
-                         clean = TRUE,
+                         clean = "ask",
                          inflate_parameters = NULL) {
-  config_file <- getOption("fusen.config_file", default = "dev/config_fusen.yaml")
+  config_file <- getOption(
+    "fusen.config_file",
+    default = "dev/config_fusen.yaml"
+  )
   state <- match.arg(state, several.ok = FALSE)
 
   # User entry verifications
@@ -242,7 +254,10 @@ df_to_config <- function(df_files,
   if (!is.data.frame(df_files) && file.exists(df_files)) {
     df_files <- read.csv(df_files, stringsAsFactors = FALSE)
   } else if (!is.data.frame(df_files) && !file.exists(df_files)) {
-    stop("'", df_files, "' does not exist. You can run `check_not_registered_files()` before.")
+    stop(
+      "'", df_files, "' does not exist. You can run ",
+      "`check_not_registered_files()` before."
+    )
   }
 
   # Then if is.data.frame(df_files)
@@ -270,7 +285,11 @@ df_to_config <- function(df_files,
       )
       if (isTRUE(force)) {
         cli_alert_warning(
-          paste(msg, "\nHowever, you forced to write it in the yaml file with `force = TRUE`.")
+          paste(
+            msg,
+            "\nHowever, you forced to write it in the yaml",
+            " file with `force = TRUE`."
+          )
         )
       } else {
         stop(msg)
@@ -287,7 +306,12 @@ df_to_config <- function(df_files,
     )
   }
 
-  if (!all(grepl("^R$|^r$|^test$|^tests$|^vignette$|^vignettes$", df_files[["type"]]))) {
+  if (!all(
+    grepl(
+      "^R$|^r$|^test$|^tests$|^vignette$|^vignettes$",
+      df_files[["type"]]
+    )
+  )) {
     stop("Only types 'R', 'test' or 'vignette' are allowed")
   }
   all_exists <- file.exists(df_files[["path"]])
@@ -306,7 +330,10 @@ df_to_config <- function(df_files,
 
     if (isTRUE(force)) {
       cli_alert_warning(
-        paste(msg, "\nHowever, you forced to write it in the yaml file with `force = TRUE`.")
+        paste(
+          msg,
+          "\nHowever, you forced to write it in the yaml file with `force = TRUE`."
+        )
       )
     } else {
       stop(msg)
@@ -314,7 +341,11 @@ df_to_config <- function(df_files,
   }
 
   if (!is.null(inflate_parameters) & flat_file_path == "keep") {
-    stop("The purpose of using \"keep\" is to store files created without inflate(). Therefore it is not allowed to provide inflate_parameters")
+    stop(
+      "The purpose of using \"keep\" is to store files",
+      " created without inflate(). ",
+      " Therefore it is not allowed to provide inflate_parameters"
+    )
   }
 
   # Remove common part between config_file and all path
@@ -333,30 +364,47 @@ df_to_config <- function(df_files,
   }
 
   # All origin path should exist, if not "keep"
-  if (!isTRUE(force) || isTRUE(all(file.exists(df_files$origin[df_files$origin != "keep"])))) {
+  if (
+    !isTRUE(force) ||
+      isTRUE(all(file.exists(df_files$origin[df_files$origin != "keep"])))
+  ) {
     df_files$origin[df_files$origin != "keep"] <- gsub(
       paste0(normalize_path_winslash("."), "/"),
       "",
-      normalize_path_winslash(df_files$origin[df_files$origin != "keep"], mustWork = TRUE),
+      normalize_path_winslash(
+        df_files$origin[df_files$origin != "keep"],
+        mustWork = TRUE
+      ),
       fixed = TRUE
     )
-  } else if (isFALSE(all(file.exists(df_files$origin[df_files$origin != "keep"])))) {
+  } else if (
+    isFALSE(all(file.exists(df_files$origin[df_files$origin != "keep"])))
+  ) {
     warning(
       "Please open a bug on {fusen} package with this complete message:\n",
       "There is an error in the df_to_config process.\n",
       "Files origin do not exist but will be registered as is in the config file:\n",
-      paste(df_files$origin[!file.exists(df_files$origin[df_files$origin != "keep"])],
+      paste(
+        df_files$origin[
+          !file.exists(df_files$origin[df_files$origin != "keep"])
+        ],
         collapse = ", "
       )
     )
   }
 
   if (any(duplicated(df_files$path))) {
-    msg <- paste("Some paths appear multiple times in df_files. Please remove duplicated rows: ", paste(unique(df_files$path[duplicated(df_files$path)]), collapse = ", "))
+    msg <- paste(
+      "Some paths appear multiple times in df_files. Please remove duplicated rows: ",
+      paste(unique(df_files$path[duplicated(df_files$path)]), collapse = ", ")
+    )
 
     if (isTRUE(force)) {
       cli_alert_warning(
-        paste(msg, "\nHowever, you forced to write it in the yaml file with `force = TRUE`.")
+        paste(
+          msg,
+          "\nHowever, you forced to write it in the yaml file with `force = TRUE`."
+        )
       )
     } else {
       stop(msg)
@@ -376,11 +424,16 @@ df_to_config <- function(df_files,
           yaml_paths[!all_exists],
           collapse = ", "
         ), ".\n",
-        "Please open the configuration file: ", config_file, " to verify, and delete the non-existing files if needed."
+        "Please open the configuration file: ",
+        config_file,
+        " to verify, and delete the non-existing files if needed."
       )
       if (isTRUE(force)) {
         cli_alert_warning(
-          paste(msg, "However, you forced to write it in the yaml file with `force = TRUE`.")
+          paste(
+            msg,
+            "However, you forced to write it in the yaml file with `force = TRUE`."
+          )
         )
       } else {
         stop(msg)
@@ -413,7 +466,8 @@ df_to_config <- function(df_files,
   if (length(all_modified) != 0) {
     cli_alert_info(
       paste0(
-        "Some files group already existed and were ", ifelse(isTRUE(clean), "overwritten: ", "modified: "),
+        "Some files group already existed and were ",
+        ifelse(isTRUE(clean), "overwritten: ", "modified: "),
         paste(all_modified, collapse = ", ")
       )
     )
@@ -482,16 +536,18 @@ files_list_to_vector <- function(list_of_files) {
 #' @param complete_yaml The list as output of config_yaml file
 #' @param flat_file_path The group to update
 #' @param state Character. See `df_to_config()`.
-#' @param clean Logical. See `df_to_config()`.
+#' @param clean Logical (TRUE, FALSE) or character ("ask", "yes", "no).
+#'  See `df_to_config()`.
 #' @param inflate_parameters See `df_to_config()`.
 #' @importFrom cli cli_alert_warning cli_alert_success
 #' @noRd
-update_one_group_yaml <- function(df_files,
-                                  complete_yaml,
-                                  flat_file_path,
-                                  state = c("active", "deprecated"),
-                                  clean = TRUE,
-                                  inflate_parameters = NULL) {
+update_one_group_yaml <- function(
+    df_files,
+    complete_yaml,
+    flat_file_path,
+    state = c("active", "deprecated"),
+    clean = "ask",
+    inflate_parameters = NULL) {
   state <- match.arg(state, several.ok = FALSE)
   all_keep_before <- complete_yaml[[basename(flat_file_path)]]
 
@@ -499,7 +555,7 @@ update_one_group_yaml <- function(df_files,
   df_files_filtered <- df_files[df_files[["origin"]] == flat_file_path, ]
 
   # All already in the list will be deleted except if clean is FALSE
-  if (isTRUE(clean)) {
+  if (isTRUE(clean) || clean %in% c("yes", "ask")) {
     this_group_list <- list(
       path = flat_file_path,
       state = state,
@@ -513,7 +569,7 @@ update_one_group_yaml <- function(df_files,
         grepl("^vignette$|^vignettes$", df_files_filtered[["type"]])
       ])
     )
-  } else {
+  } else if (isFALSE(clean) || clean %in% c("no")) {
     this_group_list <- list(
       path = flat_file_path,
       state = state,
@@ -535,18 +591,29 @@ update_one_group_yaml <- function(df_files,
       )),
       vignettes = unique(c(
         # new ones
-        df_files_filtered[["path"]][grepl("^vignette$|^vignettes$", df_files_filtered[["type"]])],
+        df_files_filtered[["path"]][
+          grepl(
+            "^vignette$|^vignettes$",
+            df_files_filtered[["type"]]
+          )
+        ],
         # previous ones
         unlist(all_keep_before[["vignettes"]])
       ))
     )
+  } else {
+    stop("clean should be TRUE, FALSE, 'yes', 'no' or 'ask'")
   }
 
   this_group_list_return <- this_group_list
   this_group_list_message <- this_group_list
   if (!is.null(inflate_parameters)) {
-    this_group_list_return <- c(this_group_list, list(inflate = inflate_parameters))
-    this_group_list_message <- c(this_group_list, list(inflate = "each parameter"))
+    this_group_list_return <- c(
+      this_group_list, list(inflate = inflate_parameters)
+    )
+    this_group_list_message <- c(
+      this_group_list, list(inflate = "each parameter")
+    )
   }
 
   # Messages only
@@ -576,10 +643,19 @@ update_one_group_yaml <- function(df_files,
   those_added_vec <- files_list_to_vector(those_added)
 
   if (!is.null(those_removed_vec) || length(those_removed_vec) != 0) {
-    silent <- lapply(paste(those_removed_vec, "was removed from the config file"), cli_alert_warning)
+    silent <- lapply(
+      paste(those_removed_vec, "was removed from the config file"),
+      cli_alert_warning
+    )
+    if (clean == "ask") {
+      # TODO
+    }
   }
   if (!is.null(those_added_vec) || length(those_added_vec) != 0) {
-    silent <- lapply(paste(those_added_vec, "was added to the config file"), cli_alert_success)
+    silent <- lapply(
+      paste(those_added_vec, "was added to the config file"),
+      cli_alert_success
+    )
   }
 
   return(this_group_list_return)

--- a/dev/config_fusen.yaml
+++ b/dev/config_fusen.yaml
@@ -51,9 +51,10 @@ flat_inflate_all.Rmd:
     flat_file: dev/flat_inflate_all.Rmd
     vignette_name: Inflate all your flat files
     open_vignette: false
-    check: true
+    check: false
     document: true
     overwrite: 'yes'
+    clean: ask
 flat_inflate_all_utils.Rmd:
   path: dev/flat_inflate_all_utils.Rmd
   state: active
@@ -71,6 +72,7 @@ flat_inflate_all_utils.Rmd:
     check: false
     document: true
     overwrite: 'yes'
+    clean: ask
 flat_init_share_on_github.Rmd:
   path: dev/flat_init_share_on_github.Rmd
   state: active
@@ -97,6 +99,7 @@ flat_register_config_file.Rmd:
     check: false
     document: true
     overwrite: 'yes'
+    clean: ask
 keep:
   path: keep
   state: active

--- a/dev/dev_history_cran.R
+++ b/dev/dev_history_cran.R
@@ -26,8 +26,10 @@ testthat::test_dir("tests/testthat/")
 testthat::test_file("tests/testthat/test-inflate-part1.R")
 testthat::test_file("tests/testthat/test-inflate-part2.R")
 testthat::test_file("tests/testthat/test-inflate_all.R")
+testthat::test_file("tests/testthat/test-inflate_all_utils.R")
 testthat::test_file("tests/testthat/test-add_flat_template.R")
 testthat::test_file("tests/testthat/test-skeleton.R")
+testthat::test_file("tests/testthat/test-register_config_file.R")
 Sys.setenv("NOT_CRAN" = "false")
 
 # Run line by line

--- a/dev/dev_history_cran.R
+++ b/dev/dev_history_cran.R
@@ -29,12 +29,12 @@ testthat::test_file("tests/testthat/test-inflate_all.R")
 testthat::test_file("tests/testthat/test-inflate_all_utils.R")
 testthat::test_file("tests/testthat/test-add_flat_template.R")
 testthat::test_file("tests/testthat/test-skeleton.R")
-testthat::test_file("tests/testthat/test-register_config_file.R")
+testthat::test_file("tests/testthat/test-register_config_file.R") # interactivity
 Sys.setenv("NOT_CRAN" = "false")
 
 # Run line by line
 Sys.setenv("FUSEN_TEST_PUBLISH" = "TRUE")
-testthat::test_file("tests/testthat/test-init_share_on_github.R")
+testthat::test_file("tests/testthat/test-init_share_on_github.R") # interactivity
 Sys.setenv("FUSEN_TEST_PUBLISH" = "FALSE")
 # testthat::test_file("tests/testthat/test-build_fusen_chunks.R")
 # Test no output generated in the user files

--- a/dev/flat_inflate_all.Rmd
+++ b/dev/flat_inflate_all.Rmd
@@ -65,8 +65,14 @@ You can run your preferred styling functions just before the check of the packag
 #' Inflate all the flat files stored in "dev/" and starting with "flat_"
 #'
 #' @param pkg Path to package
-#' @param clean Logical. Whether to help detect unregistered files.
-#' @param stylers Function to be run at the end of the process, like `styler::style_pkg` or `lintr::lint_package` or a lambda function combining functions like: `function() {styler::style_pkg(); lintr::lint_package()}`. For a unique function, use the format without parenthesis `()` at the end of the command.
+#' @param check_unregistered Logical. Whether to help detect unregistered files.
+#' Typically files not created from a flat file and added manually in the repository.
+#' @param stylers Function to be run at the end of the process,
+#' like `styler::style_pkg` or `lintr::lint_package`
+#' or a lambda function combining functions like:
+#' `function() {styler::style_pkg(); lintr::lint_package()}`.
+#' For a unique function, use the format without parenthesis `()`
+#' at the end of the command.
 #' @inheritParams inflate
 #'
 #' @importFrom yaml read_yaml
@@ -75,19 +81,36 @@ You can run your preferred styling functions just before the check of the packag
 #'
 #' @return side effect. Inflates all your flat files that can be inflated.
 #'
-#' @details This requires to [inflate()] all flat files individually at least once, so that their specific inflate configurations are stored.
+#' @details This requires to [inflate()] all flat files
+#'  individually at least once, so that their specific
+#'  inflate configurations are stored.
 #'
-#' This also requires to register all R, tests and vignettes files of your package, even if not created with an inflate. Run [inflate_all()] once and read the messages. The first time, you will probably need to run [register_all_to_config()] if your package is not new.
+#' This also requires to register all R,
+#'  tests and vignettes files of your package,
+#' even if not created with an inflate.
+#' Run [inflate_all()] once and read the messages.
+#' The first time, you will probably need to run
+#' [register_all_to_config()] if your package is not new.
 #'
-#' For more information, read the `vignette("inflate-all-your-flat-files", package = "fusen")`
+#' For more information, read the
+#'  `vignette("inflate-all-your-flat-files", package = "fusen")`
 #'
 #' @seealso
 #'   [inflate()] for the options of a single file inflate,
-#'   [check_not_registered_files()] for the list of files not already associated with a flat file in the config file,
-#'   [register_all_to_config()] for automatically registering all files already present in the project before the first `inflate_all()`
+#'   [check_not_registered_files()] for the list of files
+#' not already associated with a flat file in the config file,
+#'   [register_all_to_config()] for automatically registering
+#' all files already present in the project before the first `inflate_all()`
 #'
 #' @export
-inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, stylers, ...) {
+inflate_all <- function(
+    pkg = ".",
+    document = TRUE,
+    check = TRUE,
+    open_vignette = FALSE,
+    overwrite = TRUE,
+    check_unregistered = TRUE,
+    stylers, ...) {
   config_file <- getOption("fusen.config_file", default = "dev/config_fusen.yaml")
 
   if (!file.exists(config_file)) {
@@ -124,7 +147,9 @@ inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette 
     message("No flat files were inflated")
   } else {
     apply_inflate <- function(inflate_params, pkg, overwrite, open_vignette) {
-      config_file <- getOption("fusen.config_file", default = "dev/config_fusen.yaml")
+      config_file <- getOption("fusen.config_file",
+        default = "dev/config_fusen.yaml"
+      )
       # Change config option temporary, to be able to modify it on the fly
       config_file_tmp <- tempfile(pattern = "tempconfig")
       on.exit(file.remove(config_file_tmp))
@@ -144,10 +169,13 @@ inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette 
       )
     }
 
-    apply_inflate(inflate_params, pkg = pkg, overwrite = overwrite, open_vignette = open_vignette)
+    apply_inflate(inflate_params,
+      pkg = pkg, overwrite = overwrite,
+      open_vignette = open_vignette
+    )
   }
 
-  if (isTRUE(clean)) {
+  if (isTRUE(check_unregistered)) {
     cli::cat_rule("check not registered files")
     invisible(check_not_registered_files(path = pkg))
   }
@@ -176,8 +204,8 @@ inflate_all <- function(pkg = ".", document = TRUE, check = TRUE, open_vignette 
 
 #' @rdname inflate_all
 #' @export
-inflate_all_no_check <- function(pkg = ".", document = TRUE, open_vignette = FALSE, overwrite = TRUE, clean = TRUE, stylers, ...) {
-  inflate_all(pkg = pkg, document = document, check = FALSE, open_vignette = open_vignette, overwrite = overwrite, clean = clean, stylers, ...)
+inflate_all_no_check <- function(pkg = ".", document = TRUE, open_vignette = FALSE, overwrite = TRUE, check_unregistered = TRUE, stylers, ...) {
+  inflate_all(pkg = pkg, document = document, check = FALSE, open_vignette = open_vignette, overwrite = overwrite, check_unregistered = check_unregistered, stylers, ...)
 }
 ```
   
@@ -636,7 +664,10 @@ usethis::with_project(dummypackage, {
       file = file.path(dummypackage, "R", "unregistered_r.R")
     )
     cat("# unregistered file in test\n",
-      file = file.path(dummypackage, "tests", "testthat", "test-unregistered_r.R")
+      file = file.path(
+        dummypackage,
+        "tests", "testthat", "test-unregistered_r.R"
+      )
     )
 
     expect_message(
@@ -664,11 +695,14 @@ usethis::with_project(dummypackage, {
       row.names = 1:2,
       class = "data.frame"
     )
-    csv_content_expected <- csv_content_expected[order(csv_content_expected[["path"]]), ]
+    csv_content_expected <-
+      csv_content_expected[order(csv_content_expected[["path"]]), ]
 
     expect_equal(csv_content, csv_content_expected)
 
-    config_content <- yaml::read_yaml(file.path(dummypackage, "dev", "config_fusen.yaml"))
+    config_content <- yaml::read_yaml(
+      file.path(dummypackage, "dev", "config_fusen.yaml")
+    )
 
     expect_true(
       !is.null(config_content[["flat_minimal.Rmd"]][["inflate"]])
@@ -679,7 +713,9 @@ usethis::with_project(dummypackage, {
     # register everything
     register_all_to_config()
 
-    config_content <- yaml::read_yaml(file.path(dummypackage, "dev", "config_fusen.yaml"))
+    config_content <- yaml::read_yaml(
+      file.path(dummypackage, "dev", "config_fusen.yaml")
+    )
 
     expect_true(
       !is.null(config_content[["flat_minimal.Rmd"]][["inflate"]])
@@ -700,7 +736,7 @@ usethis::with_project(dummypackage, {
   })
 
   test_that("inflate_all is does not check registered if FALSE", {
-    output <- capture.output(inflate_all_no_check(clean = FALSE))
+    output <- capture.output(inflate_all_no_check(check_unregistered = FALSE))
     expect_false(any(grepl("registered", output)))
   })
 
@@ -779,7 +815,7 @@ usethis::with_project(dummypackage, {
       names(config_content[["flat_full.Rmd"]][["inflate"]]),
       c(
         "flat_file", "vignette_name", "open_vignette",
-        "check", "document", "overwrite"
+        "check", "document", "overwrite", "clean"
       )
     )
   })
@@ -829,7 +865,7 @@ usethis::with_project(dummypackage, {
       names(config_content[["flat_full.Rmd"]][["inflate"]]),
       c(
         "flat_file", "vignette_name", "open_vignette",
-        "check", "document", "overwrite"
+        "check", "document", "overwrite", "clean"
       )
     )
     expect_true(is.na(config_content[["flat_full.Rmd"]][["inflate"]][["vignette_name"]]))
@@ -900,7 +936,7 @@ usethis::with_project(dummypackage, {
 fusen::inflate(
   flat_file = "dev/flat_inflate_all.Rmd",
   vignette_name = "Inflate all your flat files",
-  check = TRUE, # args = c("--no-manual", "--no-tests"),
+  check = FALSE, # args = c("--no-manual", "--no-tests"),
   overwrite = TRUE,
   open_vignette = FALSE
 )

--- a/dev/flat_inflate_all_utils.Rmd
+++ b/dev/flat_inflate_all_utils.Rmd
@@ -806,7 +806,8 @@ usethis::with_project(dummypackage, {
         open_vignette = FALSE,
         check = FALSE,
         document = TRUE,
-        overwrite = "ask"
+        overwrite = "ask",
+        clean = "ask"
       )
     )
 
@@ -818,7 +819,8 @@ usethis::with_project(dummypackage, {
         open_vignette = FALSE,
         check = FALSE,
         document = TRUE,
-        overwrite = "ask"
+        overwrite = "ask",
+        clean = "ask"
       )
     )
   })

--- a/dev/flat_register_config_file.Rmd
+++ b/dev/flat_register_config_file.Rmd
@@ -794,13 +794,20 @@ unlink(dummypackage, recursive = TRUE)
 #' @param df_files A data.frame with 'type' and 'path' columns
 #' or a csv file path as issued from `[check_not_registered_files()]`
 #' or nothing (and it will take the csv file in "dev/")
-#' @param flat_file_path Character. Usually set to `"keep"` for users. You can use the name of the origin flat file but this is more of an internal use, as inflating the flat file should have the same result.
+#' @param flat_file_path Character. Usually set to `"keep"` for users.
+#' You can use the name of the origin flat file but this is more of
+#' an internal use, as inflating the flat file should have the same result.
 #' @param state Character. Whether if the flat file is `active` or `deprecated`.
-#' @param force Logical. Whether to force writing the configuration file even is some files do not exist.
-#' @param clean Logical. Delete list associated to a specific flat file before updating the whole list.
-#' Default is set to TRUE during `inflate()` of a specific flat file, as the list should only contain files created during the inflate.
-#' This could be set to FALSE with a direct use of `df_to_config()` too. This is forced to FALSE for "keep" section.
-#' @param inflate_parameters list of parameters passed through a call to `inflate()`
+#' @param force Logical. Whether to force writing the configuration
+#' file even is some files do not exist.
+#' @param clean Logical (TRUE, FALSE) or character ("ask", "yes", "no).
+#' Whether to delete files created in a previous version of this flat file
+#' Default is set to "ask" during `inflate()` of a specific flat file,
+#' as the list should only contain files created during the inflate.
+#' This could be set to FALSE with a direct use of `df_to_config()` too.
+#' This is forced to FALSE for the "keep" section.
+#' @param inflate_parameters list of parameters passed through
+#' a call to `inflate()`
 
 #' @importFrom stats setNames
 #' @importFrom utils read.csv
@@ -810,8 +817,10 @@ unlink(dummypackage, recursive = TRUE)
 #' Side effect: create a yaml config file.
 #'
 #' @seealso
-#'   [check_not_registered_files()] for the list of files not already associated with a flat file in the config file,
-#'   [register_all_to_config()] for automatically registering all files already present in the project
+#'   [check_not_registered_files()] for the list of files not already
+#'  associated with a flat file in the config file,
+#'   [register_all_to_config()] for automatically registering
+#'  all files already present in the project
 #'
 #' @noRd
 
@@ -819,9 +828,12 @@ df_to_config <- function(df_files,
                          flat_file_path = "keep",
                          state = c("active", "deprecated"),
                          force = FALSE,
-                         clean = TRUE,
+                         clean = "ask",
                          inflate_parameters = NULL) {
-  config_file <- getOption("fusen.config_file", default = "dev/config_fusen.yaml")
+  config_file <- getOption(
+    "fusen.config_file",
+    default = "dev/config_fusen.yaml"
+  )
   state <- match.arg(state, several.ok = FALSE)
 
   # User entry verifications
@@ -833,7 +845,10 @@ df_to_config <- function(df_files,
   if (!is.data.frame(df_files) && file.exists(df_files)) {
     df_files <- read.csv(df_files, stringsAsFactors = FALSE)
   } else if (!is.data.frame(df_files) && !file.exists(df_files)) {
-    stop("'", df_files, "' does not exist. You can run `check_not_registered_files()` before.")
+    stop(
+      "'", df_files, "' does not exist. You can run ",
+      "`check_not_registered_files()` before."
+    )
   }
 
   # Then if is.data.frame(df_files)
@@ -861,7 +876,11 @@ df_to_config <- function(df_files,
       )
       if (isTRUE(force)) {
         cli_alert_warning(
-          paste(msg, "\nHowever, you forced to write it in the yaml file with `force = TRUE`.")
+          paste(
+            msg,
+            "\nHowever, you forced to write it in the yaml",
+            " file with `force = TRUE`."
+          )
         )
       } else {
         stop(msg)
@@ -878,7 +897,12 @@ df_to_config <- function(df_files,
     )
   }
 
-  if (!all(grepl("^R$|^r$|^test$|^tests$|^vignette$|^vignettes$", df_files[["type"]]))) {
+  if (!all(
+    grepl(
+      "^R$|^r$|^test$|^tests$|^vignette$|^vignettes$",
+      df_files[["type"]]
+    )
+  )) {
     stop("Only types 'R', 'test' or 'vignette' are allowed")
   }
   all_exists <- file.exists(df_files[["path"]])
@@ -897,7 +921,10 @@ df_to_config <- function(df_files,
 
     if (isTRUE(force)) {
       cli_alert_warning(
-        paste(msg, "\nHowever, you forced to write it in the yaml file with `force = TRUE`.")
+        paste(
+          msg,
+          "\nHowever, you forced to write it in the yaml file with `force = TRUE`."
+        )
       )
     } else {
       stop(msg)
@@ -905,7 +932,11 @@ df_to_config <- function(df_files,
   }
 
   if (!is.null(inflate_parameters) & flat_file_path == "keep") {
-    stop("The purpose of using \"keep\" is to store files created without inflate(). Therefore it is not allowed to provide inflate_parameters")
+    stop(
+      "The purpose of using \"keep\" is to store files",
+      " created without inflate(). ",
+      " Therefore it is not allowed to provide inflate_parameters"
+    )
   }
 
   # Remove common part between config_file and all path
@@ -924,30 +955,47 @@ df_to_config <- function(df_files,
   }
 
   # All origin path should exist, if not "keep"
-  if (!isTRUE(force) || isTRUE(all(file.exists(df_files$origin[df_files$origin != "keep"])))) {
+  if (
+    !isTRUE(force) ||
+      isTRUE(all(file.exists(df_files$origin[df_files$origin != "keep"])))
+  ) {
     df_files$origin[df_files$origin != "keep"] <- gsub(
       paste0(normalize_path_winslash("."), "/"),
       "",
-      normalize_path_winslash(df_files$origin[df_files$origin != "keep"], mustWork = TRUE),
+      normalize_path_winslash(
+        df_files$origin[df_files$origin != "keep"],
+        mustWork = TRUE
+      ),
       fixed = TRUE
     )
-  } else if (isFALSE(all(file.exists(df_files$origin[df_files$origin != "keep"])))) {
+  } else if (
+    isFALSE(all(file.exists(df_files$origin[df_files$origin != "keep"])))
+  ) {
     warning(
       "Please open a bug on {fusen} package with this complete message:\n",
       "There is an error in the df_to_config process.\n",
       "Files origin do not exist but will be registered as is in the config file:\n",
-      paste(df_files$origin[!file.exists(df_files$origin[df_files$origin != "keep"])],
+      paste(
+        df_files$origin[
+          !file.exists(df_files$origin[df_files$origin != "keep"])
+        ],
         collapse = ", "
       )
     )
   }
 
   if (any(duplicated(df_files$path))) {
-    msg <- paste("Some paths appear multiple times in df_files. Please remove duplicated rows: ", paste(unique(df_files$path[duplicated(df_files$path)]), collapse = ", "))
+    msg <- paste(
+      "Some paths appear multiple times in df_files. Please remove duplicated rows: ",
+      paste(unique(df_files$path[duplicated(df_files$path)]), collapse = ", ")
+    )
 
     if (isTRUE(force)) {
       cli_alert_warning(
-        paste(msg, "\nHowever, you forced to write it in the yaml file with `force = TRUE`.")
+        paste(
+          msg,
+          "\nHowever, you forced to write it in the yaml file with `force = TRUE`."
+        )
       )
     } else {
       stop(msg)
@@ -967,11 +1015,16 @@ df_to_config <- function(df_files,
           yaml_paths[!all_exists],
           collapse = ", "
         ), ".\n",
-        "Please open the configuration file: ", config_file, " to verify, and delete the non-existing files if needed."
+        "Please open the configuration file: ",
+        config_file,
+        " to verify, and delete the non-existing files if needed."
       )
       if (isTRUE(force)) {
         cli_alert_warning(
-          paste(msg, "However, you forced to write it in the yaml file with `force = TRUE`.")
+          paste(
+            msg,
+            "However, you forced to write it in the yaml file with `force = TRUE`."
+          )
         )
       } else {
         stop(msg)
@@ -1004,7 +1057,8 @@ df_to_config <- function(df_files,
   if (length(all_modified) != 0) {
     cli_alert_info(
       paste0(
-        "Some files group already existed and were ", ifelse(isTRUE(clean), "overwritten: ", "modified: "),
+        "Some files group already existed and were ",
+        ifelse(isTRUE(clean), "overwritten: ", "modified: "),
         paste(all_modified, collapse = ", ")
       )
     )
@@ -1073,16 +1127,18 @@ files_list_to_vector <- function(list_of_files) {
 #' @param complete_yaml The list as output of config_yaml file
 #' @param flat_file_path The group to update
 #' @param state Character. See `df_to_config()`.
-#' @param clean Logical. See `df_to_config()`.
+#' @param clean Logical (TRUE, FALSE) or character ("ask", "yes", "no).
+#'  See `df_to_config()`.
 #' @param inflate_parameters See `df_to_config()`.
 #' @importFrom cli cli_alert_warning cli_alert_success
 #' @noRd
-update_one_group_yaml <- function(df_files,
-                                  complete_yaml,
-                                  flat_file_path,
-                                  state = c("active", "deprecated"),
-                                  clean = TRUE,
-                                  inflate_parameters = NULL) {
+update_one_group_yaml <- function(
+    df_files,
+    complete_yaml,
+    flat_file_path,
+    state = c("active", "deprecated"),
+    clean = "ask",
+    inflate_parameters = NULL) {
   state <- match.arg(state, several.ok = FALSE)
   all_keep_before <- complete_yaml[[basename(flat_file_path)]]
 
@@ -1090,7 +1146,7 @@ update_one_group_yaml <- function(df_files,
   df_files_filtered <- df_files[df_files[["origin"]] == flat_file_path, ]
 
   # All already in the list will be deleted except if clean is FALSE
-  if (isTRUE(clean)) {
+  if (isTRUE(clean) || clean %in% c("yes", "ask")) {
     this_group_list <- list(
       path = flat_file_path,
       state = state,
@@ -1104,7 +1160,7 @@ update_one_group_yaml <- function(df_files,
         grepl("^vignette$|^vignettes$", df_files_filtered[["type"]])
       ])
     )
-  } else {
+  } else if (isFALSE(clean) || clean %in% c("no")) {
     this_group_list <- list(
       path = flat_file_path,
       state = state,
@@ -1126,18 +1182,29 @@ update_one_group_yaml <- function(df_files,
       )),
       vignettes = unique(c(
         # new ones
-        df_files_filtered[["path"]][grepl("^vignette$|^vignettes$", df_files_filtered[["type"]])],
+        df_files_filtered[["path"]][
+          grepl(
+            "^vignette$|^vignettes$",
+            df_files_filtered[["type"]]
+          )
+        ],
         # previous ones
         unlist(all_keep_before[["vignettes"]])
       ))
     )
+  } else {
+    stop("clean should be TRUE, FALSE, 'yes', 'no' or 'ask'")
   }
 
   this_group_list_return <- this_group_list
   this_group_list_message <- this_group_list
   if (!is.null(inflate_parameters)) {
-    this_group_list_return <- c(this_group_list, list(inflate = inflate_parameters))
-    this_group_list_message <- c(this_group_list, list(inflate = "each parameter"))
+    this_group_list_return <- c(
+      this_group_list, list(inflate = inflate_parameters)
+    )
+    this_group_list_message <- c(
+      this_group_list, list(inflate = "each parameter")
+    )
   }
 
   # Messages only
@@ -1167,10 +1234,19 @@ update_one_group_yaml <- function(df_files,
   those_added_vec <- files_list_to_vector(those_added)
 
   if (!is.null(those_removed_vec) || length(those_removed_vec) != 0) {
-    silent <- lapply(paste(those_removed_vec, "was removed from the config file"), cli_alert_warning)
+    silent <- lapply(
+      paste(those_removed_vec, "was removed from the config file"),
+      cli_alert_warning
+    )
+    if (clean == "ask") {
+      # TODO
+    }
   }
   if (!is.null(those_added_vec) || length(those_added_vec) != 0) {
-    silent <- lapply(paste(those_added_vec, "was added to the config file"), cli_alert_success)
+    silent <- lapply(
+      paste(those_added_vec, "was added to the config file"),
+      cli_alert_success
+    )
   }
 
   return(this_group_list_return)
@@ -1240,6 +1316,66 @@ config_file <- df_to_config(
 ```
 
 ```{r tests-df_to_config}
+# Test update_one_group_yaml ----
+temp_clean_inflate <- tempfile(pattern = "clean.update.config")
+dir.create(temp_clean_inflate)
+
+withr::with_dir(temp_clean_inflate, {
+  dir.create(file.path("R"))
+  dir.create(file.path("tests", "testthat"), recursive = TRUE)
+  dir.create(file.path("vignettes"))
+  dir.create(file.path("dev"))
+
+  cat("# test R file\n", file = file.path("R", "to_keep.R"))
+  cat("# test R file\n", file = file.path("R", "to_remove.R"))
+  cat("# test test file\n",
+    file = file.path("tests", "testthat", "test-zaza.R")
+  )
+  cat("# test flat file\n", file = file.path("dev", "flat_test.Rmd"))
+
+
+  all_files <- tibble::tribble(
+    ~type, ~path,
+    "R", "R/to_keep.R",
+    "R", "R/to_remove.R",
+    "test", "tests/testthat/test-zaza.R"
+  )
+
+  config_file <- df_to_config(
+    all_files,
+    flat_file_path = "dev/flat_test.Rmd",
+    state = "active"
+  )
+
+  # Simulate function to_remove() was changed for to_add()
+  # Then file to_remove.R should be removed
+  # from the config file and from the repository
+  cat("# test R file\n", file = file.path("R", "to_add.R"))
+
+  all_files_new <- tibble::tribble(
+    ~origin, ~type, ~path,
+    "dev/flat_test.Rmd", "R", "R/to_keep.R",
+    "dev/flat_test.Rmd", "R", "R/to_add.R",
+    "dev/flat_test.Rmd", "test", "tests/testthat/test-zaza.R"
+  )
+
+  browser()
+  debugonce(update_one_group_yaml)
+  update_one_group_yaml(
+    all_files_new,
+    complete_yaml = yaml::read_yaml(config_file),
+    flat_file_path = "dev/flat_test.Rmd",
+    state = "active"
+  )
+
+  test_that("update_one_group_yaml clean old files", {
+    expect_true(file.exists("R/to_add.R"))
+    expect_false(file.exists("R/to_remove.R"))
+    expect_true(file.exists("tests/testthat/test-zaza.R"))
+  })
+})
+
+
 # Test df_to_config with custom config file path ----
 config_file_path <- tempfile(fileext = ".yaml")
 

--- a/dev/flat_register_config_file.Rmd
+++ b/dev/flat_register_config_file.Rmd
@@ -1196,54 +1196,94 @@ update_one_group_yaml <- function(
   }
 
   this_group_list_return <- this_group_list
-  this_group_list_message <- this_group_list
   if (!is.null(inflate_parameters)) {
     this_group_list_return <- c(
       this_group_list, list(inflate = inflate_parameters)
     )
-    this_group_list_message <- c(
-      this_group_list, list(inflate = "each parameter")
-    )
   }
 
   # Messages only
-  all_names <- names(this_group_list_message)
-  those_removed <- lapply(
+  all_names <- c("R", "tests", "vignettes")
+  # names(this_group_list_message)
+  files_removed <- lapply(
     all_names,
     function(x) {
       setdiff(
         all_keep_before[[x]],
-        this_group_list_message[[x]]
+        this_group_list_return[[x]]
       )
     }
   ) %>%
     setNames(all_names)
+  files_removed_vec <- files_list_to_vector(files_removed)
 
-  those_removed_vec <- files_list_to_vector(those_removed)
-  those_added <- lapply(
+  files_added <- lapply(
     all_names,
     function(x) {
       setdiff(
-        this_group_list_message[[x]],
+        this_group_list_return[[x]],
         all_keep_before[[x]]
       )
     }
   ) %>%
     setNames(all_names)
-  those_added_vec <- files_list_to_vector(those_added)
+  files_added_vec <- files_list_to_vector(files_added)
 
-  if (!is.null(those_removed_vec) || length(those_removed_vec) != 0) {
-    silent <- lapply(
-      paste(those_removed_vec, "was removed from the config file"),
-      cli_alert_warning
-    )
+  if (!is.null(files_removed_vec) || length(files_removed_vec) != 0) {
     if (clean == "ask") {
-      # TODO
+      cli_alert_warning(
+        paste0(
+          "Some files are not anymore created from ",
+          flat_file_path, ".\n",
+          "You may have rename some functions or moved them to another flat:",
+          "\n",
+          paste(files_removed_vec, collapse = ", "), ".\n\n",
+          "Below, you are ask if you want to remove them from the repository.",
+          "\n\n",
+          "Note: to not see this message again, use `clean = TRUE` in the ",
+          "`inflate()` command of this flat file : ", flat_file_path, ".\n",
+          "Use with caution. ",
+          "It is recommended to use git to check the changes...\n"
+        )
+      )
+      sure <- paste(
+        paste(files_removed_vec, collapse = ", "),
+        "\nDo you want to remove all these files from the repository? (y/n)\n"
+      )
+
+      do_it <- readline(sure) == "y" || readline(sure) == "yes"
+    } else if (isTRUE(clean) || clean == "yes") {
+      do_it <- TRUE
+    } else if (isFALSE(clean) || clean == "no") {
+      do_it <- FALSE
+    } else {
+      stop("clean should be TRUE, FALSE, 'yes', 'no' or 'ask'")
+    }
+
+    if (isTRUE(do_it)) {
+      files_removed_filename <- unlist(files_removed)
+      file.remove(files_removed_filename)
+
+      silent <- lapply(
+        paste(
+          files_removed_vec, "was removed from the config file",
+          "and from the repository"
+        ),
+        cli_alert_warning
+      )
+    } else if (isFALSE(do_it)) {
+      silent <- lapply(
+        paste(
+          files_removed_vec, "was removed from the config file",
+          "but kept in the repository"
+        ),
+        cli_alert_warning
+      )
     }
   }
-  if (!is.null(those_added_vec) || length(those_added_vec) != 0) {
+  if (!is.null(files_added_vec) || length(files_added_vec) != 0) {
     silent <- lapply(
-      paste(those_added_vec, "was added to the config file"),
+      paste(files_added_vec, "was added to the config file"),
       cli_alert_success
     )
   }
@@ -1321,6 +1361,20 @@ temp_clean_inflate <- tempfile(pattern = "clean.update.config")
 dir.create(temp_clean_inflate)
 
 withr::with_dir(temp_clean_inflate, {
+  # Need to force edition to allow expect_snapshot
+  # As we are in another directory using with_dir()
+  local_edition(3)
+  # Fix output conditions for this test for snapshots
+  local_reproducible_output(
+    width = 100,
+    crayon = FALSE,
+    unicode = FALSE,
+    rstudio = FALSE,
+    hyperlinks = FALSE,
+    lang = "en",
+    .env = parent.frame()
+  )
+
   dir.create(file.path("R"))
   dir.create(file.path("tests", "testthat"), recursive = TRUE)
   dir.create(file.path("vignettes"))
@@ -1341,11 +1395,27 @@ withr::with_dir(temp_clean_inflate, {
     "test", "tests/testthat/test-zaza.R"
   )
 
-  config_file <- df_to_config(
-    all_files,
-    flat_file_path = "dev/flat_test.Rmd",
-    state = "active"
+
+  # Get all messages once
+  expect_snapshot(
+    df_to_config(
+      all_files,
+      flat_file_path = "dev/flat_test.Rmd",
+      state = "active",
+      inflate_parameters = list(
+        flat_file = "dev/flat_test.Rmd",
+        vignette_name = "My new vignette",
+        open_vignette = FALSE,
+        check = FALSE,
+        document = TRUE,
+        overwrite = "yes",
+        clean = "ask"
+      )
+    )
   )
+
+  config_file <- "dev/config_fusen.yaml"
+
 
   # Simulate function to_remove() was changed for to_add()
   # Then file to_remove.R should be removed
@@ -1359,21 +1429,66 @@ withr::with_dir(temp_clean_inflate, {
     "dev/flat_test.Rmd", "test", "tests/testthat/test-zaza.R"
   )
 
-  # TODO
-  # browser()
-  # debugonce(update_one_group_yaml)
-  update_one_group_yaml(
-    all_files_new,
-    complete_yaml = yaml::read_yaml(config_file),
-    flat_file_path = "dev/flat_test.Rmd",
-    state = "active"
+  # Get all messages once with snapshot
+  expect_snapshot(
+    update_one_group_yaml(
+      all_files_new,
+      complete_yaml = yaml::read_yaml(config_file),
+      flat_file_path = "dev/flat_test.Rmd",
+      state = "active",
+      clean = TRUE,
+      inflate_parameters = list(
+        flat_file = "dev/flat_test.Rmd",
+        vignette_name = "My new vignette",
+        open_vignette = FALSE,
+        check = FALSE,
+        document = TRUE,
+        overwrite = "yes",
+        clean = TRUE
+      )
+    )
   )
 
   test_that("update_one_group_yaml clean old files", {
     expect_true(file.exists("R/to_add.R"))
-    # expect_false(file.exists("R/to_remove.R")) # TODO - Uncomment
+    expect_false(file.exists("R/to_remove.R"))
     expect_true(file.exists("tests/testthat/test-zaza.R"))
   })
+
+  if (interactive()) {
+    # Allows to test in interactive session
+    # to see if you were asked to remove the file
+    file.create(file.path("R", "to_remove.R"))
+    test_that("update_one_group_yaml file is back before interactive", {
+      expect_true(file.exists("R/to_add.R"))
+      expect_true(file.exists("R/to_remove.R"))
+      expect_true(file.exists("tests/testthat/test-zaza.R"))
+    })
+
+    update_one_group_yaml(
+      all_files_new,
+      complete_yaml = yaml::read_yaml(config_file),
+      flat_file_path = "dev/flat_test.Rmd",
+      state = "active",
+      # Allows to test in interactive session
+      clean = "ask",
+      inflate_parameters = list(
+        flat_file = "dev/flat_test.Rmd",
+        vignette_name = "My new vignette",
+        open_vignette = FALSE,
+        check = FALSE,
+        document = TRUE,
+        overwrite = "yes",
+        clean = TRUE
+      )
+    )
+
+    test_that("update_one_group_yaml clean old files after interactive", {
+      expect_true(file.exists("R/to_add.R"))
+      expect_false(file.exists("R/to_remove.R"))
+      expect_true(file.exists("tests/testthat/test-zaza.R"))
+    })
+  }
 })
 
 
@@ -1406,9 +1521,9 @@ test_that("df_to_config fails when appropriate", {
       "Some 'path' in df_files do not exist: row 1- R: zaza.R, row 2- R: zozo.R, row 3- test: test-zaza.R"
     )
 
-    expect_error(
-      config_file_out <- df_to_config(all_files, force = TRUE),
-      regexp = NA
+
+    expect_no_error(
+      config_file_out <- df_to_config(all_files, force = TRUE)
     )
 
     expect_equal(config_file_out, config_file_path)
@@ -1450,7 +1565,10 @@ test_that("df_to_config works", {
     expect_equal(config_file_out, config_file_path)
     all_keep <- yaml::read_yaml(config_file_out)
     expect_equal(names(all_keep), "keep")
-    expect_equal(names(all_keep$keep), c("path", "state", "R", "tests", "vignettes"))
+    expect_equal(
+      names(all_keep$keep),
+      c("path", "state", "R", "tests", "vignettes")
+    )
     expect_equal(all_keep$keep$path, c("keep"))
     expect_equal(all_keep$keep$state, c("active"))
     expect_equal(all_keep$keep$R, c("zaza.R", "zozo.R"))
@@ -1468,7 +1586,10 @@ all_files <- tibble::tribble(
   "vignettes", "tata_vignette.Rmd"
 )
 
-file.create(file.path(dir_tmp, c("tata.R", "toto.R", "test-tata.R", "tata_vignette.Rmd")))
+file.create(file.path(
+  dir_tmp,
+  c("tata.R", "toto.R", "test-tata.R", "tata_vignette.Rmd")
+))
 
 
 test_that("df_to_config works after 2nd run", {
@@ -1505,15 +1626,20 @@ test_that("df_to_config works with files having no content", {
         "vignette", file.path("vignettes", "my-vignette.Rmd")
       )
 
-      expect_message(config_file_out <- df_to_config(all_files),
-        regexp = "vignettes: vignettes/my-vignette.Rmd was added to the config file"
+      expect_message(
+        config_file_out <- df_to_config(all_files),
+        regexp =
+          "vignettes: vignettes/my-vignette.Rmd was added to the config file"
       )
     })
 
     expect_equal(config_file_out, config_file_path)
     all_keep <- yaml::read_yaml(config_file_out)
     expect_equal(names(all_keep), "keep")
-    expect_equal(names(all_keep$keep), c("path", "state", "R", "tests", "vignettes"))
+    expect_equal(
+      names(all_keep$keep),
+      c("path", "state", "R", "tests", "vignettes")
+    )
     expect_equal(all_keep$keep$path, c("keep"))
     expect_equal(all_keep$keep$state, c("active"))
     # Relative path
@@ -1553,41 +1679,46 @@ dir_tmp <- tempfile()
 dir.create(dir_tmp)
 file.create(file.path(dir_tmp, c("zaza.R", "zozo.R", "test-zaza.R")))
 
-test_that("df_to_config does not work with inflate_parameters and flat_file_path = \"keep\"", {
-  withr::with_dir(dir_tmp, {
-    withr::with_options(list(fusen.config_file = config_file_path), {
-      all_files <- tibble::tribble(
-        ~type, ~path,
-        "R", "zaza.R",
-        "R", "zozo.R",
-        "test", "test-zaza.R"
-      )
+test_that(
+  "df_to_config fails with inflate_parameters and flat_file_path = \"keep\"",
+  {
+    withr::with_dir(dir_tmp, {
+      withr::with_options(list(fusen.config_file = config_file_path), {
+        all_files <- tibble::tribble(
+          ~type, ~path,
+          "R", "zaza.R",
+          "R", "zozo.R",
+          "test", "test-zaza.R"
+        )
 
-      expect_error(
-        df_to_config(all_files,
-          inflate_parameters = list(
-            flat_file = "dev/my_flat.Rmd",
-            vignette_name = "My new vignette",
-            open_vignette = FALSE,
-            check = FALSE,
-            document = TRUE,
-            overwrite = "yes",
-            clean = "ask"
+        expect_error(
+          df_to_config(all_files,
+            inflate_parameters = list(
+              flat_file = "dev/my_flat.Rmd",
+              vignette_name = "My new vignette",
+              open_vignette = FALSE,
+              check = FALSE,
+              document = TRUE,
+              overwrite = "yes",
+              clean = "ask"
+            )
           )
         )
-      )
+      })
     })
-  })
-})
+  }
+)
 
 unlink(dir_tmp, recursive = TRUE)
 
 # df to config with inflate_parameters
-# unlink(dummypackage, recursive = TRUE)
 dummypackage <- tempfile("dftoconfig")
 dir.create(dummypackage)
 fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
-dev_file <- (add_minimal_package(pkg = dummypackage, overwrite = TRUE, open = FALSE))
+dev_file <- (add_minimal_package(
+  pkg = dummypackage,
+  overwrite = TRUE, open = FALSE
+))
 # let's create a flat file
 flat_file <- dev_file[grepl("flat_", dev_file)]
 
@@ -1655,7 +1786,9 @@ dir.create(dummypackage)
 
 # {fusen} steps
 fill_description(pkg = dummypackage, fields = list(Title = "Dummy Package"))
-dev_file <- suppressMessages(add_flat_template(pkg = dummypackage, overwrite = TRUE, open = FALSE))
+dev_file <- suppressMessages(
+  add_flat_template(pkg = dummypackage, overwrite = TRUE, open = FALSE)
+)
 flat_file <- dev_file[grepl("flat_", dev_file)]
 
 test_that("inflate parameters are put into config_fusen.yaml", {
@@ -1670,7 +1803,9 @@ test_that("inflate parameters are put into config_fusen.yaml", {
       )
     )
 
-    config_yml <- yaml::read_yaml(file.path(dummypackage, "dev/config_fusen.yaml"))
+    config_yml <- yaml::read_yaml(
+      file.path(dummypackage, "dev/config_fusen.yaml")
+    )
 
     expect_equal(
       config_yml[[basename(flat_file)]][["inflate"]][["vignette_name"]],
@@ -1706,22 +1841,33 @@ test_that("inflate parameters are put into config_fusen.yaml", {
     )
 
     # Let's inflate a second time with different parameters
-
     suppressMessages(
       inflate(
         pkg = dummypackage, flat_file = flat_file,
-        vignette_name = "Get started again", check = FALSE,
+        vignette_name = "Get started again",
+        clean = TRUE, # clean previous vignette
+        check = FALSE,
         open_vignette = FALSE, overwrite = "yes",
         extra_param = "tutu", document = FALSE
       )
     )
 
-    config_yml <- yaml::read_yaml(file.path(dummypackage, "dev/config_fusen.yaml"))
+    config_yml <- yaml::read_yaml(
+      file.path(dummypackage, "dev/config_fusen.yaml")
+    )
 
     expect_equal(
       config_yml[[basename(flat_file)]][["inflate"]][["vignette_name"]],
       "Get started again"
     )
+    # Previous vignette deleted
+    expect_true(
+      file.exists(file.path("vignettes", "get-started-again.Rmd"))
+    )
+    expect_false(
+      file.exists(file.path("vignettes", "get-started.Rmd"))
+    )
+
 
     expect_false(
       config_yml[[basename(flat_file)]][["inflate"]][["check"]]
@@ -1740,11 +1886,9 @@ test_that("inflate parameters are put into config_fusen.yaml", {
       "yes"
     )
 
-    expect_equal(
-      config_yml[[basename(flat_file)]][["inflate"]][["clean"]],
-      "ask"
+    expect_true(
+      config_yml[[basename(flat_file)]][["inflate"]][["clean"]]
     )
-
 
     expect_equal(
       config_yml[[basename(flat_file)]][["inflate"]][["extra_param"]],

--- a/dev/flat_register_config_file.Rmd
+++ b/dev/flat_register_config_file.Rmd
@@ -1057,8 +1057,7 @@ df_to_config <- function(df_files,
   if (length(all_modified) != 0) {
     cli_alert_info(
       paste0(
-        "Some files group already existed and were ",
-        ifelse(isTRUE(clean), "overwritten: ", "modified: "),
+        "Some files group already existed and were modified: ",
         paste(all_modified, collapse = ", ")
       )
     )
@@ -1309,7 +1308,8 @@ config_file <- df_to_config(
     open_vignette = FALSE,
     check = FALSE,
     document = TRUE,
-    overwrite = "yes"
+    overwrite = "yes",
+    clean = "ask"
   )
 )
 #' }
@@ -1359,8 +1359,9 @@ withr::with_dir(temp_clean_inflate, {
     "dev/flat_test.Rmd", "test", "tests/testthat/test-zaza.R"
   )
 
-  browser()
-  debugonce(update_one_group_yaml)
+  # TODO
+  # browser()
+  # debugonce(update_one_group_yaml)
   update_one_group_yaml(
     all_files_new,
     complete_yaml = yaml::read_yaml(config_file),
@@ -1370,7 +1371,7 @@ withr::with_dir(temp_clean_inflate, {
 
   test_that("update_one_group_yaml clean old files", {
     expect_true(file.exists("R/to_add.R"))
-    expect_false(file.exists("R/to_remove.R"))
+    # expect_false(file.exists("R/to_remove.R")) # TODO - Uncomment
     expect_true(file.exists("tests/testthat/test-zaza.R"))
   })
 })
@@ -1469,12 +1470,13 @@ all_files <- tibble::tribble(
 
 file.create(file.path(dir_tmp, c("tata.R", "toto.R", "test-tata.R", "tata_vignette.Rmd")))
 
+
 test_that("df_to_config works after 2nd run", {
   withr::with_dir(dir_tmp, {
     withr::with_options(list(fusen.config_file = config_file_path), {
       expect_message(
         config_file <- df_to_config(all_files),
-        regexp = "Some files group already existed and were overwritten: keep"
+        regexp = "Some files group already existed and were modified: keep"
       ) # "keep" is default
     })
   })
@@ -1569,7 +1571,8 @@ test_that("df_to_config does not work with inflate_parameters and flat_file_path
             open_vignette = FALSE,
             check = FALSE,
             document = TRUE,
-            overwrite = "yes"
+            overwrite = "yes",
+            clean = "ask"
           )
         )
       )
@@ -1623,7 +1626,8 @@ test_that("df_to_config works with inflate parameters", {
         open_vignette = FALSE,
         check = FALSE,
         document = TRUE,
-        overwrite = "yes"
+        overwrite = "yes",
+        clean = "ask"
       )
     )
 
@@ -1637,7 +1641,8 @@ test_that("df_to_config works with inflate parameters", {
         open_vignette = FALSE,
         check = FALSE,
         document = TRUE,
-        overwrite = "yes"
+        overwrite = "yes",
+        clean = "ask"
       )
     )
   })
@@ -1689,6 +1694,11 @@ test_that("inflate parameters are put into config_fusen.yaml", {
       "ask"
     )
 
+    expect_equal(
+      config_yml[[basename(flat_file)]][["inflate"]][["clean"]],
+      "ask"
+    )
+
 
     expect_equal(
       config_yml[[basename(flat_file)]][["inflate"]][["extra_param"]],
@@ -1728,6 +1738,11 @@ test_that("inflate parameters are put into config_fusen.yaml", {
     expect_equal(
       config_yml[[basename(flat_file)]][["inflate"]][["overwrite"]],
       "yes"
+    )
+
+    expect_equal(
+      config_yml[[basename(flat_file)]][["inflate"]][["clean"]],
+      "ask"
     )
 
 

--- a/inst/flat-template-teaching.Rmd
+++ b/inst/flat-template-teaching.Rmd
@@ -29,7 +29,7 @@ Note: when you will use other flat templates, this part will be in a separate fi
 fusen::fill_description(
   pkg = here::here(),
   fields = list(
-    Title = "Learn how to build A Package From Rmarkdown file",
+    Title = "Learn How to Build a Package from Rmarkdown File",
     Description = "A Set of tools to understand packages structure. Use Rmarkdown First method to build a package from a defined template. Start your package with documentation. Everything can be set from a Rmarkdown file in your project.",
     `Authors@R` = c(
       person("John", "Doe", email = "john@email.me", role = c("aut", "cre"), comment = c(ORCID = "0000-0000-0000-0000"))
@@ -55,7 +55,7 @@ This first section shows:
 
 ```{r function-add_one}
 #' Add one to any value
-#' 
+#'
 #' @param value A numeric value
 #'
 #' @return Numeric. value + 1

--- a/man/inflate.Rd
+++ b/man/inflate.Rd
@@ -12,6 +12,7 @@ inflate(
   check = TRUE,
   document = TRUE,
   overwrite = "ask",
+  clean = "ask",
   ...
 )
 }
@@ -31,6 +32,11 @@ Use \code{NA} if you do not want to create a vignette.}
 
 \item{overwrite}{Logical (TRUE, FALSE) or character ("ask", "yes", "no).
 Whether to overwrite vignette and functions if already exists.}
+
+\item{clean}{Logical (TRUE, FALSE) or character ("ask", "yes", "no)
+Whether to delete files that are not anymore created by the current
+flat file. Typically, if you have deleted or renamed a function
+in the flat file. Default to "ask".}
 
 \item{...}{Arguments passed to \code{devtools::check()}.
 For example, you can do \code{inflate(check = TRUE, quiet = TRUE)}, where \code{quiet} is

--- a/man/inflate_all.Rd
+++ b/man/inflate_all.Rd
@@ -11,7 +11,7 @@ inflate_all(
   check = TRUE,
   open_vignette = FALSE,
   overwrite = TRUE,
-  clean = TRUE,
+  check_unregistered = TRUE,
   stylers,
   ...
 )
@@ -21,7 +21,7 @@ inflate_all_no_check(
   document = TRUE,
   open_vignette = FALSE,
   overwrite = TRUE,
-  clean = TRUE,
+  check_unregistered = TRUE,
   stylers,
   ...
 )
@@ -38,9 +38,15 @@ inflate_all_no_check(
 \item{overwrite}{Logical (TRUE, FALSE) or character ("ask", "yes", "no).
 Whether to overwrite vignette and functions if already exists.}
 
-\item{clean}{Logical. Whether to help detect unregistered files.}
+\item{check_unregistered}{Logical. Whether to help detect unregistered files.
+Typically files not created from a flat file and added manually in the repository.}
 
-\item{stylers}{Function to be run at the end of the process, like \code{styler::style_pkg} or \code{lintr::lint_package} or a lambda function combining functions like: \code{function() {styler::style_pkg(); lintr::lint_package()}}. For a unique function, use the format without parenthesis \verb{()} at the end of the command.}
+\item{stylers}{Function to be run at the end of the process,
+like \code{styler::style_pkg} or \code{lintr::lint_package}
+or a lambda function combining functions like:
+\code{function() {styler::style_pkg(); lintr::lint_package()}}.
+For a unique function, use the format without parenthesis \verb{()}
+at the end of the command.}
 
 \item{...}{Arguments passed to \code{devtools::check()}.
 For example, you can do \code{inflate(check = TRUE, quiet = TRUE)}, where \code{quiet} is
@@ -53,11 +59,19 @@ side effect. Inflates all your flat files that can be inflated.
 Inflate all the flat files stored in "dev/" and starting with "flat_"
 }
 \details{
-This requires to \code{\link[=inflate]{inflate()}} all flat files individually at least once, so that their specific inflate configurations are stored.
+This requires to \code{\link[=inflate]{inflate()}} all flat files
+individually at least once, so that their specific
+inflate configurations are stored.
 
-This also requires to register all R, tests and vignettes files of your package, even if not created with an inflate. Run \code{\link[=inflate_all]{inflate_all()}} once and read the messages. The first time, you will probably need to run \code{\link[=register_all_to_config]{register_all_to_config()}} if your package is not new.
+This also requires to register all R,
+tests and vignettes files of your package,
+even if not created with an inflate.
+Run \code{\link[=inflate_all]{inflate_all()}} once and read the messages.
+The first time, you will probably need to run
+\code{\link[=register_all_to_config]{register_all_to_config()}} if your package is not new.
 
-For more information, read the \code{vignette("inflate-all-your-flat-files", package = "fusen")}
+For more information, read the
+\code{vignette("inflate-all-your-flat-files", package = "fusen")}
 }
 \examples{
 \dontrun{
@@ -118,6 +132,8 @@ unlink(dummypackage, recursive = TRUE)
 }
 \seealso{
 \code{\link[=inflate]{inflate()}} for the options of a single file inflate,
-\code{\link[=check_not_registered_files]{check_not_registered_files()}} for the list of files not already associated with a flat file in the config file,
-\code{\link[=register_all_to_config]{register_all_to_config()}} for automatically registering all files already present in the project before the first \code{inflate_all()}
+\code{\link[=check_not_registered_files]{check_not_registered_files()}} for the list of files
+not already associated with a flat file in the config file,
+\code{\link[=register_all_to_config]{register_all_to_config()}} for automatically registering
+all files already present in the project before the first \code{inflate_all()}
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,3 +1,11 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
 library(testthat)
 library(fusen)
 

--- a/tests/testthat/_snaps/register_config_file.md
+++ b/tests/testthat/_snaps/register_config_file.md
@@ -1,0 +1,63 @@
+# register_all_to_config can append new files in keep section
+
+    Code
+      df_to_config(all_files, flat_file_path = "dev/flat_test.Rmd", state = "active", inflate_parameters = list(
+        flat_file = "dev/flat_test.Rmd", vignette_name = "My new vignette", open_vignette = FALSE, check = FALSE,
+        document = TRUE, overwrite = "yes", clean = "ask"))
+    Message
+      v R: R/to_keep.R was added to the config file
+      v R: R/to_remove.R was added to the config file
+      v tests: tests/testthat/test-zaza.R was added to the config file
+    Output
+      [1] "dev/config_fusen.yaml"
+
+---
+
+    Code
+      update_one_group_yaml(all_files_new, complete_yaml = yaml::read_yaml(config_file), flat_file_path = "dev/flat_test.Rmd",
+      state = "active", clean = TRUE, inflate_parameters = list(flat_file = "dev/flat_test.Rmd",
+        vignette_name = "My new vignette", open_vignette = FALSE, check = FALSE, document = TRUE,
+        overwrite = "yes", clean = TRUE))
+    Message
+      ! R: R/to_remove.R was removed from the config file and from the repository
+      v R: R/to_add.R was added to the config file
+    Output
+      $path
+      [1] "dev/flat_test.Rmd"
+      
+      $state
+      [1] "active"
+      
+      $R
+      [1] "R/to_keep.R" "R/to_add.R" 
+      
+      $tests
+      [1] "tests/testthat/test-zaza.R"
+      
+      $vignettes
+      character(0)
+      
+      $inflate
+      $inflate$flat_file
+      [1] "dev/flat_test.Rmd"
+      
+      $inflate$vignette_name
+      [1] "My new vignette"
+      
+      $inflate$open_vignette
+      [1] FALSE
+      
+      $inflate$check
+      [1] FALSE
+      
+      $inflate$document
+      [1] TRUE
+      
+      $inflate$overwrite
+      [1] "yes"
+      
+      $inflate$clean
+      [1] TRUE
+      
+      
+

--- a/tests/testthat/config_fusen_register.yaml
+++ b/tests/testthat/config_fusen_register.yaml
@@ -15,6 +15,7 @@ flat_full.Rmd:
     check: no
     document: yes
     overwrite: ask
+    clean: ask
 flat_new_one.Rmd:
   path: dev/flat_new_one.Rmd
   state: active
@@ -28,6 +29,7 @@ flat_new_one.Rmd:
     check: no
     document: yes
     overwrite: ask
+    clean: ask
 keep:
   path: keep
   state: active

--- a/tests/testthat/test-inflate-part1.R
+++ b/tests/testthat/test-inflate-part1.R
@@ -217,6 +217,8 @@ usethis::with_project(dummypackage, {
       # if tested as cran
       # 1 note on CRAN for new submission
       print(check_out[["notes"]])
+      # DEBUG ----
+      saveRDS(check_out, "/mnt/Data/github/ThinkR-open/fusen/check_note.rds")
       expect_true(grepl("New submission", check_out[["notes"]][1]))
     } else {
       expect_true(length(check_out[["notes"]]) == 0)
@@ -479,7 +481,6 @@ usethis::with_project(dummypackage, {
       file.path(dummypackage, "tests", "testthat", "test-my_median.R")
     ))
   })
-
 })
 # Delete dummy package
 unlink(dummypackage, recursive = TRUE)
@@ -512,9 +513,8 @@ usethis::with_project(dummypackage, {
     vig_lines <- readLines(vignette_path, encoding = "UTF-8")
     expect_true(sum(grepl(enc2utf8("# y -  _ p n@ \u00E9 ! 1"), vig_lines, fixed = TRUE)) == 2)
     expect_equal(vig_lines[2], enc2utf8('title: "# y -  _ p n@ \u00E9 ! 1"'))
-    expect_equal(vig_lines[5], enc2utf8('  %\\VignetteIndexEntry{# y -  _ p n@ \u00E9 ! 1}'))
+    expect_equal(vig_lines[5], enc2utf8("  %\\VignetteIndexEntry{# y -  _ p n@ \u00E9 ! 1}"))
   })
-
 })
 # Delete dummy package
 unlink(dummypackage, recursive = TRUE)

--- a/tests/testthat/test-inflate-part1.R
+++ b/tests/testthat/test-inflate-part1.R
@@ -199,8 +199,8 @@ usethis::with_project(dummypackage, {
     # Do not check inside check if on CRAN
     skip_on_os(os = c("windows", "solaris"))
 
-    # If this check is run inside a not "--as-cran" check, then it wont work as expected
-    check_out <- rcmdcheck::rcmdcheck(dummypackage,
+    check_out <- rcmdcheck::rcmdcheck(
+      path = ".",
       quiet = TRUE,
       args = c("--no-manual")
     )
@@ -212,14 +212,22 @@ usethis::with_project(dummypackage, {
     # expect_true(grepl("license", check_out[["warnings"]][1]))
     # No Notes or only one if CRAN ?
     skip_on_cran()
-    expect_true(length(check_out[["notes"]]) <= 1)
-    if (length(check_out[["notes"]]) == 1) {
+    expect_true(length(check_out[["notes"]]) <= 2)
+    if (length(check_out[["notes"]]) %in% 1:2) {
       # if tested as cran
       # 1 note on CRAN for new submission
       print(check_out[["notes"]])
-      # DEBUG ----
-      saveRDS(check_out, "/mnt/Data/github/ThinkR-open/fusen/check_note.rds")
-      expect_true(grepl("New submission", check_out[["notes"]][1]))
+
+      note_expected <- grepl(
+        "New submission|future file timestamps|Package vignette without corresponding tangle output",
+        check_out[["notes"]]
+      )
+      expect_true(all(note_expected))
+
+      if (!all(note_expected)) {
+        # Keep here to see the notes when CI fails
+        expect_equal(check_out[["notes"]], expected = "no other note")
+      }
     } else {
       expect_true(length(check_out[["notes"]]) == 0)
     }

--- a/tests/testthat/test-inflate-part2.R
+++ b/tests/testthat/test-inflate-part2.R
@@ -448,7 +448,7 @@ usethis::with_project(dummypackage, {
       # Notes are different on CRAN
       skip_on_cran()
 
-      expect_true(length(check_out[["notes"]]) <= 1)
+      expect_true(length(check_out[["notes"]]) <= 2)
       if (length(check_out[["notes"]]) %in% 1:2) {
         note_expected <- grepl(
           "future file timestamps|Package vignette without corresponding tangle output",

--- a/tests/testthat/test-inflate_all.R
+++ b/tests/testthat/test-inflate_all.R
@@ -396,7 +396,10 @@ usethis::with_project(dummypackage, {
       file = file.path(dummypackage, "R", "unregistered_r.R")
     )
     cat("# unregistered file in test\n",
-      file = file.path(dummypackage, "tests", "testthat", "test-unregistered_r.R")
+      file = file.path(
+        dummypackage,
+        "tests", "testthat", "test-unregistered_r.R"
+      )
     )
 
     expect_message(
@@ -424,11 +427,14 @@ usethis::with_project(dummypackage, {
       row.names = 1:2,
       class = "data.frame"
     )
-    csv_content_expected <- csv_content_expected[order(csv_content_expected[["path"]]), ]
+    csv_content_expected <-
+      csv_content_expected[order(csv_content_expected[["path"]]), ]
 
     expect_equal(csv_content, csv_content_expected)
 
-    config_content <- yaml::read_yaml(file.path(dummypackage, "dev", "config_fusen.yaml"))
+    config_content <- yaml::read_yaml(
+      file.path(dummypackage, "dev", "config_fusen.yaml")
+    )
 
     expect_true(
       !is.null(config_content[["flat_minimal.Rmd"]][["inflate"]])
@@ -439,7 +445,9 @@ usethis::with_project(dummypackage, {
     # register everything
     register_all_to_config()
 
-    config_content <- yaml::read_yaml(file.path(dummypackage, "dev", "config_fusen.yaml"))
+    config_content <- yaml::read_yaml(
+      file.path(dummypackage, "dev", "config_fusen.yaml")
+    )
 
     expect_true(
       !is.null(config_content[["flat_minimal.Rmd"]][["inflate"]])
@@ -460,7 +468,7 @@ usethis::with_project(dummypackage, {
   })
 
   test_that("inflate_all is does not check registered if FALSE", {
-    output <- capture.output(inflate_all_no_check(clean = FALSE))
+    output <- capture.output(inflate_all_no_check(check_unregistered = FALSE))
     expect_false(any(grepl("registered", output)))
   })
 
@@ -539,7 +547,7 @@ usethis::with_project(dummypackage, {
       names(config_content[["flat_full.Rmd"]][["inflate"]]),
       c(
         "flat_file", "vignette_name", "open_vignette",
-        "check", "document", "overwrite"
+        "check", "document", "overwrite", "clean"
       )
     )
   })
@@ -589,7 +597,7 @@ usethis::with_project(dummypackage, {
       names(config_content[["flat_full.Rmd"]][["inflate"]]),
       c(
         "flat_file", "vignette_name", "open_vignette",
-        "check", "document", "overwrite"
+        "check", "document", "overwrite", "clean"
       )
     )
     expect_true(is.na(config_content[["flat_full.Rmd"]][["inflate"]][["vignette_name"]]))

--- a/tests/testthat/test-inflate_all_utils.R
+++ b/tests/testthat/test-inflate_all_utils.R
@@ -443,7 +443,8 @@ usethis::with_project(dummypackage, {
         open_vignette = FALSE,
         check = FALSE,
         document = TRUE,
-        overwrite = "ask"
+        overwrite = "ask",
+        clean = "ask"
       )
     )
 
@@ -455,7 +456,8 @@ usethis::with_project(dummypackage, {
         open_vignette = FALSE,
         check = FALSE,
         document = TRUE,
-        overwrite = "ask"
+        overwrite = "ask",
+        clean = "ask"
       )
     )
   })

--- a/vignettes/inflate-all-your-flat-files.Rmd
+++ b/vignettes/inflate-all-your-flat-files.Rmd
@@ -2,7 +2,7 @@
 title: "Inflate all your flat files"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{inflate-all-your-flat-files}
+  %\VignetteIndexEntry{Inflate all your flat files}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/register-files-in-config.Rmd
+++ b/vignettes/register-files-in-config.Rmd
@@ -3,7 +3,7 @@ title: "Register files in config"
 output: rmarkdown::html_vignette
 inflate_state: "active"
 vignette: >
-  %\VignetteIndexEntry{register-files-in-config}
+  %\VignetteIndexEntry{Register files in config}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/share-on-a-github-website.Rmd
+++ b/vignettes/share-on-a-github-website.Rmd
@@ -2,7 +2,7 @@
 title: "Share on a GitHub website"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{share-on-a-github-website}
+  %\VignetteIndexEntry{Share on a GitHub website}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
`inflate()` detects functions renamed or removed and allow cleaning the package repository (#24)

- Example with `add_one()` => `new_add_one()`
![image](https://github.com/ThinkR-open/fusen/assets/21193866/4149ab08-92f6-4669-be76-0c664134003e)

- Example after `filename=my-chosen-filename`
![image](https://github.com/ThinkR-open/fusen/assets/21193866/6abc3403-2fe1-4464-a923-dffd892909da)
