### PR TITLE
fix: sepuku deals with "keep" section in fusen config yml

### DIFF
--- a/R/sepuku_utils.R
+++ b/R/sepuku_utils.R
@@ -12,6 +12,7 @@ list_flat_files_in_config_file <- function(
     return(character(0))
   } else {
     config_yml <- yaml::read_yaml(config_file)
+    config_yml <- config_yml[!names(config_yml) %in% "keep"]
     return(
       unlist(
         lapply(config_yml, "[[", "path")

--- a/dev/flat_sepuku-utils.Rmd
+++ b/dev/flat_sepuku-utils.Rmd
@@ -30,6 +30,7 @@ list_flat_files_in_config_file <- function(
     return(character(0))
   } else {
     config_yml <- yaml::read_yaml(config_file)
+    config_yml <- config_yml[!names(config_yml) %in% "keep"]
     return(
       unlist(
         lapply(config_yml, "[[", "path")


### PR DESCRIPTION
sepuku was raising a warning when a keep section was present in the fusen config file