### PR TITLE
Make sure the parent directory exists

### DIFF
--- a/tests/testthat/test-create_fusen_rsproject.R
+++ b/tests/testthat/test-create_fusen_rsproject.R
@@ -137,6 +137,7 @@ for (template.to.try in fusen:::create_fusen_choices) {
 
 ## Create in a subdirectory ----
 dummysubdir <- tempfile(pattern = "subdir/subdir2/dummy")
+dir.create(dirname(dummysubdir), recursive = TRUE)
 test_that("Can create in a subdirectory", {
   expect_error(suppressMessages(create_fusen(dummysubdir, template = "full", open = FALSE)), regexp = NA)
   expect_true(dir.exists(dummysubdir))


### PR DESCRIPTION
Fixes #276 

It appears that this test setup inadvertently worked in the past, but no longer does as a side effect of the commit I mention in #276.

But the `path` argument of the `create_*()` functions has long been documented like so (emphasis mine, for this conversation):

> A path. If it exists, it is used. If it does not exist, it is created, **provided that the parent path exists**.

So this PR makes sure that the directory `{TMPDIR}/subdir/subdir2` exists prior to trying to create a project in it. Apparently this worked in the past, but it was always sort of counter to the docs.